### PR TITLE
chore: 指定openai依赖版本的最低版本号,避免版本过低导致无法调用chatgpt对应api

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-openai
+openai>=0.27.0
 gradio
 markdown


### PR DESCRIPTION
如果机器之前装过openai依赖，默认用 `pip install -r requirements.txt` 并不会升级版本，导致调用时无法调用 chatgpt 对应api。

因此在依赖库里增加版本号要求