### PR TITLE
增加前后置引导选项

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,16 @@
 <img height="128" align="left" src="https://user-images.githubusercontent.com/51039745/222689546-7612df0e-e28b-4693-9f5f-4ef2be3daf48.png" alt="Logo">
 
-# 川虎 ChatGPT / Chuanhu ChatGPT
+# ( NSFW解限测试版 ) 川虎 ChatGPT / Chuanhu ChatGPT
+
+## 变动
+相比原版，这个实验性的Repo增加了「前置引导」和「后置诱导」功能。
+为部分包含敏感场景的文学创作(例如NSFW)提供了支持。
+---
 
 [![LICENSE](https://img.shields.io/github/license/GaiZhenbiao/ChuanhuChatGPT)](https://github.com/GaiZhenbiao/ChuanhuChatGPT/blob/main/LICENSE)
 [![Base](https://img.shields.io/badge/Base-Gradio-fb7d1a?style=flat)](https://gradio.app/)
 [![Bilibili](https://img.shields.io/badge/Bilibili-%E8%A7%86%E9%A2%91%E6%95%99%E7%A8%8B-ff69b4?style=flat&logo=bilibili)](https://www.bilibili.com/video/BV1mo4y1r7eE)
 
----
 
 为ChatGPT API提供了一个Web图形界面。在Bilibili上[观看视频教程](https://www.bilibili.com/video/BV1mo4y1r7eE/)。也在Hugging Face上[在线体验](https://huggingface.co/spaces/JohnSmith9982/ChuanhuChatGPT)。
 

--- a/README.md
+++ b/README.md
@@ -1,17 +1,26 @@
 <img height="128" align="left" src="https://user-images.githubusercontent.com/51039745/222689546-7612df0e-e28b-4693-9f5f-4ef2be3daf48.png" alt="Logo">
 
-# ( NSFW解限测试版 ) 川虎 ChatGPT / Chuanhu ChatGPT
+# ( NSFW测试版 ) 川虎 ChatGPT / Chuanhu ChatGPT
 
-## 变动
-相比原版，这个实验性的Repo增加了「前置引导」和「后置诱导」功能。
-为部分包含敏感场景的文学创作(例如NSFW)提供了支持。
 ---
 
 [![LICENSE](https://img.shields.io/github/license/GaiZhenbiao/ChuanhuChatGPT)](https://github.com/GaiZhenbiao/ChuanhuChatGPT/blob/main/LICENSE)
 [![Base](https://img.shields.io/badge/Base-Gradio-fb7d1a?style=flat)](https://gradio.app/)
 [![Bilibili](https://img.shields.io/badge/Bilibili-%E8%A7%86%E9%A2%91%E6%95%99%E7%A8%8B-ff69b4?style=flat&logo=bilibili)](https://www.bilibili.com/video/BV1mo4y1r7eE)
 
+## 变动
+相比原版，这个实验性的Repo增加了「前置引导」和「后置诱导」功能。
 
+为部分包含敏感场景的文学创作(例如NSFW)提供了支持。
+
+⚠️请在遵循您所在地区法律法规的前提下使用⚠️
+
+## 引导示例
+
+<img width="1010" alt="image" src="https://user-images.githubusercontent.com/3683548/223109242-8a7aa98f-c09c-4521-a5c2-69be717e592d.png">
+
+
+## 简介
 为ChatGPT API提供了一个Web图形界面。在Bilibili上[观看视频教程](https://www.bilibili.com/video/BV1mo4y1r7eE/)。也在Hugging Face上[在线体验](https://huggingface.co/spaces/JohnSmith9982/ChuanhuChatGPT)。
 
 <img width="1420" alt="截屏2023-03-04 11 29 50 1" src="https://user-images.githubusercontent.com/51039745/222873690-d046dfa1-8941-49ff-92a2-fef34421c503.png">


### PR DESCRIPTION
为项目增加了「前置引导」和「后置诱导」选项。

前置引导:  
提交时在头部插入虚拟记录（不存入history），以便在某些需要语气微调的场景提供问答示例。
为AI的回复提供基准模板。

后置诱导：
在一些敏感的文学创作场景(例如各种NSFW，描绘凶杀现场，虚拟犯罪，欺骗和阴谋时)。 
通过插入虚拟的后置模拟对话，避免AI频繁拒绝创作(同样不存入history)。
此外，也可以通过这种方式进行重点重申和强调。

![image](https://user-images.githubusercontent.com/3683548/223123302-e326348e-1288-4bed-bd52-6df0428887bd.png)

