### PR TITLE
优化代码框样式

### DIFF
--- a/ChuanhuChatbot.py
+++ b/ChuanhuChatbot.py
@@ -48,7 +48,7 @@ def parse_text(text):
             count += 1
             items = line.split('`')
             if count % 2 == 1:
-                lines[i] = f'<pre><code class="{items[-1]}" style="display: block; white-space: pre; padding: 0 1em 1em 1em; color: #fff; background: #000;">'
+                lines[i] = f'<pre><code class="{items[-1]}" style="display: block; white-space: pre; background-color: hsl(0, 0%, 32%); border-radius: 8px; padding: 0px 1em 1em; margin-top: 1em; font-size: initial;">'
                 firstline = True
             else:
                 lines[i] = f'</code></pre>'


### PR DESCRIPTION
<img width="639" alt="image" src="https://user-images.githubusercontent.com/23137268/223484406-f5a201ab-a4aa-41f2-aaa9-0d5fe2a2533e.png">

（不用细看 commit comment）
（虽然但是，这样会在加载历史对话后重新总结对话时占用更多的token吗？）
另外有没有可能改进行内代码的样式，能看出已经打了`<code>`了，但是怎么覆盖gradio的样式呢？