### PR TITLE
增加代码高亮功能，resolve #93 (code/syntax highlighting)

### DIFF
--- a/presets.py
+++ b/presets.py
@@ -23,9 +23,78 @@ pre code {
     background-color: hsla(0, 0%, 0%, 72%);
     border: solid 5px var(--color-border-primary) !important;
     border-radius: 10px;
-    padding: 0 1.2rem 1.2rem;
-    margin-top: 1em !important;
+    padding: 1rem 1.2rem 1rem;
+    margin: 1em 0 1em;
     color: #FFF;
     box-shadow: inset 0px 8px 16px hsla(0, 0%, 0%, .2)
 }
+.codehilite .hll { background-color: #49483e }
+.codehilite .c { color: #75715e } /* Comment */
+.codehilite .err { color: #960050; background-color: #1e0010 } /* Error */
+.codehilite .k { color: #66d9ef } /* Keyword */
+.codehilite .l { color: #ae81ff } /* Literal */
+.codehilite .n { color: #f8f8f2 } /* Name */
+.codehilite .o { color: #f92672 } /* Operator */
+.codehilite .p { color: #f8f8f2 } /* Punctuation */
+.codehilite .ch { color: #75715e } /* Comment.Hashbang */
+.codehilite .cm { color: #75715e } /* Comment.Multiline */
+.codehilite .cp { color: #75715e } /* Comment.Preproc */
+.codehilite .cpf { color: #75715e } /* Comment.PreprocFile */
+.codehilite .c1 { color: #75715e } /* Comment.Single */
+.codehilite .cs { color: #75715e } /* Comment.Special */
+.codehilite .gd { color: #f92672 } /* Generic.Deleted */
+.codehilite .ge { font-style: italic } /* Generic.Emph */
+.codehilite .gi { color: #a6e22e } /* Generic.Inserted */
+.codehilite .gs { font-weight: bold } /* Generic.Strong */
+.codehilite .gu { color: #75715e } /* Generic.Subheading */
+.codehilite .kc { color: #66d9ef } /* Keyword.Constant */
+.codehilite .kd { color: #66d9ef } /* Keyword.Declaration */
+.codehilite .kn { color: #f92672 } /* Keyword.Namespace */
+.codehilite .kp { color: #66d9ef } /* Keyword.Pseudo */
+.codehilite .kr { color: #66d9ef } /* Keyword.Reserved */
+.codehilite .kt { color: #66d9ef } /* Keyword.Type */
+.codehilite .ld { color: #e6db74 } /* Literal.Date */
+.codehilite .m { color: #ae81ff } /* Literal.Number */
+.codehilite .s { color: #e6db74 } /* Literal.String */
+.codehilite .na { color: #a6e22e } /* Name.Attribute */
+.codehilite .nb { color: #f8f8f2 } /* Name.Builtin */
+.codehilite .nc { color: #a6e22e } /* Name.Class */
+.codehilite .no { color: #66d9ef } /* Name.Constant */
+.codehilite .nd { color: #a6e22e } /* Name.Decorator */
+.codehilite .ni { color: #f8f8f2 } /* Name.Entity */
+.codehilite .ne { color: #a6e22e } /* Name.Exception */
+.codehilite .nf { color: #a6e22e } /* Name.Function */
+.codehilite .nl { color: #f8f8f2 } /* Name.Label */
+.codehilite .nn { color: #f8f8f2 } /* Name.Namespace */
+.codehilite .nx { color: #a6e22e } /* Name.Other */
+.codehilite .py { color: #f8f8f2 } /* Name.Property */
+.codehilite .nt { color: #f92672 } /* Name.Tag */
+.codehilite .nv { color: #f8f8f2 } /* Name.Variable */
+.codehilite .ow { color: #f92672 } /* Operator.Word */
+.codehilite .w { color: #f8f8f2 } /* Text.Whitespace */
+.codehilite .mb { color: #ae81ff } /* Literal.Number.Bin */
+.codehilite .mf { color: #ae81ff } /* Literal.Number.Float */
+.codehilite .mh { color: #ae81ff } /* Literal.Number.Hex */
+.codehilite .mi { color: #ae81ff } /* Literal.Number.Integer */
+.codehilite .mo { color: #ae81ff } /* Literal.Number.Oct */
+.codehilite .sa { color: #e6db74 } /* Literal.String.Affix */
+.codehilite .sb { color: #e6db74 } /* Literal.String.Backtick */
+.codehilite .sc { color: #e6db74 } /* Literal.String.Char */
+.codehilite .dl { color: #e6db74 } /* Literal.String.Delimiter */
+.codehilite .sd { color: #e6db74 } /* Literal.String.Doc */
+.codehilite .s2 { color: #e6db74 } /* Literal.String.Double */
+.codehilite .se { color: #ae81ff } /* Literal.String.Escape */
+.codehilite .sh { color: #e6db74 } /* Literal.String.Heredoc */
+.codehilite .si { color: #e6db74 } /* Literal.String.Interpol */
+.codehilite .sx { color: #e6db74 } /* Literal.String.Other */
+.codehilite .sr { color: #e6db74 } /* Literal.String.Regex */
+.codehilite .s1 { color: #e6db74 } /* Literal.String.Single */
+.codehilite .ss { color: #e6db74 } /* Literal.String.Symbol */
+.codehilite .bp { color: #f8f8f2 } /* Name.Builtin.Pseudo */
+.codehilite .fm { color: #a6e22e } /* Name.Function.Magic */
+.codehilite .vc { color: #f8f8f2 } /* Name.Variable.Class */
+.codehilite .vg { color: #f8f8f2 } /* Name.Variable.Global */
+.codehilite .vi { color: #f8f8f2 } /* Name.Variable.Instance */
+.codehilite .vm { color: #f8f8f2 } /* Name.Variable.Magic */
+.codehilite .il { color: #ae81ff } /* Literal.Number.Integer.Long */
 """

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 gradio
 mdtex2html
 pypinyin
+Pygments

--- a/utils.py
+++ b/utils.py
@@ -42,12 +42,13 @@ def postprocess(
             y[i] = (
                 # None if message is None else markdown.markdown(message),
                 # None if response is None else markdown.markdown(response),
-                None if message is None else mdtex2html.convert((message)),
-                None if response is None else mdtex2html.convert(response),
+                None if message is None else mdtex2html.convert(message, extensions=['fenced_code','codehilite']),
+                None if response is None else mdtex2html.convert(response, extensions=['fenced_code','codehilite']),
             )
         return y
 
 def parse_text(text):
+    return text
     lines = text.split("\n")
     lines = [line for line in lines if line != ""]
     count = 0


### PR DESCRIPTION
需要更多测试和修改。
* 引入了 Pygments 库用以高亮。
  可以从此处挑选喜欢的高亮样式: https://pygments.org/styles/ , 目前选用了`monokai`.
* 是否可以完全剔除 parse_text 有待商榷。——如果剔除不该使用把return提前的方式（
  直接移除可能存在换行`<br/>`问题。
* 是否存在其他的 bug 有待测试。

<img width="954" alt="image" src="https://user-images.githubusercontent.com/23137268/224370291-e2c85463-e227-4ace-a597-4d559419f467.png">

相关信息：
> - https://python-markdown.github.io/extensions/code_hilite/
> - https://python-markdown.github.io/extensions/fenced_code_blocks/
> - https://python-markdown.github.io/extensions/ （或许是否有必要再引入一些其他插件，比如`tables`什么的？）