### PR TITLE
修复API赋值bug，防止已设置的API被空文件覆盖

### DIFF
--- a/ChuanhuChatbot.py
+++ b/ChuanhuChatbot.py
@@ -37,7 +37,7 @@ if dockerflag:
     if not (isinstance(username, type(None)) or isinstance(password, type(None))):
         authflag = True
 else:
-    if os.path.exists("api_key.txt"):
+    if not my_api_key and os.path.exists("api_key.txt") and os.path.getsize("api_key.txt"):
         with open("api_key.txt", "r") as f:
             my_api_key = f.read().strip()
     if os.path.exists("auth.json"):


### PR DESCRIPTION
API在获取文件中API时并没有检测API是否已被赋值，这会导致命令行或者直接在文件添加的API失效。也没有检测文件是否为空，这会导致默认存在的api_key.txt空文件把已赋值的API覆盖掉。该request修复bug，提高代码健壮性。