### PR TITLE
前置总结，保留最近的对话

### DIFF
--- a/presets.py
+++ b/presets.py
@@ -49,3 +49,6 @@ max_token_all = 3500 # 非流式对话时的最大 token 数
 timeout_all = 200 # 非流式对话时的超时时间
 enable_streaming_option = True  # 是否启用选择选择是否实时显示回答的勾选框
 HIDE_MY_KEY = False # 如果你想在UI中隐藏你的 API 密钥，将此值设置为 True
+ENABLE_SILENT_SUM = True
+silent_sum_at = 2048
+


### PR DESCRIPTION
**仅讨论该PR是否有必要，目前仅经过了简单测试，不着急merge**

很多Issue里都提到了一些关于token超出上限的特殊情况，因此这里给出另一套实现思路：

- 在predict函数中，首先统计history的长度，如果history超出某一个上限~3000，那么先行进行精简
- 非流式地生成精简结果后，从头扫描一遍history，直到token达到~2000，删除这部分history，并以固定地Prompt替换：

    user：[ChatGPT刚刚给出的结果]（刚刚我们谈到了……），你了解了吗？
    assistant: 我了解了。
    user: [原来的2000~3000聊天内容]

相比原来的实现，具有以下优势：

- 更加稳定，当前情况下，是在生成后再精简，如果用户本段token太长，除非用户先手动精简，否则将在触发一次“error”后被动地触发精简，用户体验差。
- 精简必将损失一些信息，用户对于最近的信息的精确性要求比聊天最开始的信息精确性要求更高
- 利于用户继续进行追问，否则上一条信息中的细节将因精简而消失，且由于该精简为被动触发，用户完全没有机会避免。

具体实现在utils.py 的以下函数中：
```
def silent_summarize(openai_api_key, system_prompt, history, temperature, top_p, selected_model, all_token_counts)
```