### PR TITLE
fix windows.bat

### DIFF
--- a/chatgpt - windows.bat
+++ b/chatgpt - windows.bat
@@ -2,7 +2,7 @@
 echo Opening ChuanhuChatGPT...
 
 REM Open powershell via bat
-start powershell.exe -NoExit -Command "python path\to\ChuanhuChatbot.py"
+start powershell.exe -NoExit -Command "python ./ChuanhuChatbot.py"
 
 REM The web page can be accessed with delayed start http://127.0.0.1:7860/
 ping -n 5 127.0.0.1>nul


### PR DESCRIPTION
###  Description of changes
将 chatgpt - windows.bat 文件中的path/to 改为相对路径
path/to在这里作为一个占位符，未经配置会导致运行.bat出现错误，因为运行时会被误认为绝对路径。
使用相对路径可以修复这个问题