### PR TITLE
增长流式对话超时时长

### DIFF
--- a/presets.py
+++ b/presets.py
@@ -83,7 +83,7 @@ ssl_error_prompt = "SSL错误，无法获取对话。" # SSL 错误
 no_apikey_msg = "API key长度不是51位，请检查是否输入正确。" # API key 长度不足 51 位
 
 max_token_streaming = 3500 # 流式对话时的最大 token 数
-timeout_streaming = 15 # 流式对话时的超时时间
+timeout_streaming = 30 # 流式对话时的超时时间
 max_token_all = 3500 # 非流式对话时的最大 token 数
 timeout_all = 200 # 非流式对话时的超时时间
 enable_streaming_option = True  # 是否启用选择选择是否实时显示回答的勾选框


### PR DESCRIPTION
修改流式对话超时时间（timeout_streaming）为30（翻倍），以应对OpenAI近日服务器紧缺和不足导致的api.openai.com回复request不及时的现象 经过本地测试，将timeout_streaming设为30，可有效缓解因API响应不及时而错误出现报错的现象 The streaming dialogue timeout (timeout_streaming) has been modified to 30 (doubled) to address the issue of api.openai.com responding to requests late due to recent server shortages and insufficiencies at OpenAI. After local testing, setting timeout_streaming to 30 can effectively alleviate the error reporting caused by API response delays.