### PR TITLE
修复windows系统读取josn文件编码问题报错

### DIFF
--- a/ChuanhuChatbot.py
+++ b/ChuanhuChatbot.py
@@ -44,7 +44,7 @@ else:
         with open("api_key.txt", "r") as f:
             my_api_key = f.read().strip()
     if os.path.exists("auth.json"):
-        with open("auth.json", "r") as f:
+        with open("auth.json", "r", encoding='utf-8') as f:
             auth = json.load(f)
             username = auth["username"]
             password = auth["password"]


### PR DESCRIPTION
Traceback (most recent call last):
  File "C:\Users\Administrator\Desktop\ChuanhuChatGPT\ChuanhuChatbot.py", line 48, in <module>
    auth = json.load(f)
           ^^^^^^^^^^^^
  File "C:\Users\Administrator\AppData\Local\Programs\Python\Python311\Lib\json\__init__.py", line 293, in load
    return loads(fp.read(),
                 ^^^^^^^^^
UnicodeDecodeError: 'gbk' codec can't decode byte 0x8d in position 28: illegal multibyte sequence