### PR TITLE
feat: 在页脚加入环境版本信息 【pull request 示例】

### DIFF
--- a/ChuanhuChatbot.py
+++ b/ChuanhuChatbot.py
@@ -227,7 +227,7 @@ with gr.Blocks(css=customCSS, theme=small_and_beautiful_theme) as demo:
                         changeProxyBtn = gr.Button("🔄 设置代理地址")
 
     gr.Markdown(description)
-
+    gr.HTML(footer.format(versions=versions_html()), elem_id="footer")
     chatgpt_predict_args = dict(
         fn=predict,
         inputs=[

--- a/assets/custom.css
+++ b/assets/custom.css
@@ -3,6 +3,21 @@
     --chatbot-color-dark: #121111;
 }
 
+/* 覆盖gradio的页脚信息QAQ */
+footer {
+    display: none !important;
+}
+#footer{
+    text-align: center;
+}
+#footer div{
+    display: inline-block;
+}
+#footer .versions{
+    font-size: 85%;
+    opacity: 0.85;
+}
+
 /* status_display */
 #status_display {
     display: flex;

--- a/modules/presets.py
+++ b/modules/presets.py
@@ -41,6 +41,10 @@ description = """\
 </div>
 """
 
+footer = """\
+<div class="versions">{versions}</div>
+"""
+
 summarize_prompt = "你是谁？我们刚才聊了什么？"  # 总结对话时的 prompt
 
 MODELS = [

--- a/modules/utils.py
+++ b/modules/utils.py
@@ -489,11 +489,15 @@ def versions_html():
         commit_hash = run(f"{git} rev-parse HEAD").strip()
     except Exception:
         commit_hash = "<none>"
-    short_commit = commit_hash[0:7]
+    if commit_hash != "<none>":
+        short_commit = commit_hash[0:7]
+        commit_info = f"<a style=\"text-decoration:none\" href=\"https://github.com/GaiZhenbiao/ChuanhuChatGPT/commit/{short_commit}\">{short_commit}</a>"
+    else:
+        commit_info = "unknown \U0001F615"
     return f"""
 Python: <span title="{sys.version}">{python_version}</span>
  • 
 Gradio: {gr.__version__}
  • 
-commit: <a style="text-decoration:none" href="https://github.com/GaiZhenbiao/ChuanhuChatGPT/commit/{short_commit}">{short_commit}</a>
+Commit: {commit_info}
 """


### PR DESCRIPTION
### 描述

- 在网页页脚加入python、gradio、项目提交的环境版本信息
- 去掉gradio原有的“build with gradio”等~~无关~~信息(\/ω＼)

#### 页面截图

| **before** | **after** |
|----|----|
|<img width="421" alt="image" src="https://user-images.githubusercontent.com/23137268/228274074-976a4b01-5954-424c-849b-18d60f28851f.png">|<img width="454" alt="image" src="https://user-images.githubusercontent.com/23137268/228273645-e4636508-1dd3-4e14-9b1d-112c7a9d2e6d.png">|

### 相关问题

无
_其实是希望能解决大家提ISSUE时不给出环境版本信息的问题QAQ_

### 补充信息

- 移植了[ stable-diffusion-webui](https://github.com/AUTOMATIC1111/stable-diffusion-webui) 的部分代码，但其中的`run`函数似乎是用来判断命令是否能成功运行（否则在输出错误信息）用的。是否可以去除我并不清楚QAQ
- 不知道直接下载zip安装的用户能否读取到 git 的 commit 信息，以及如果无法读取的显示效果如何
- 不知道部署在hugging face中会怎么样显示

#### 开发进度

- [x] 完成代码移植
- [ ] 讨论`run`函数是否值得保留
- [x] 测试多个平台的显示效果

------

_另外，这也是一个符合[ 贡献指南](https://github.com/GaiZhenbiao/ChuanhuChatGPT/wiki/贡献指南) 标准的示例 pull request。_