### PR TITLE
bugfix: 上传同名索引文件bug

### DIFF
--- a/modules/llama_func.py
+++ b/modules/llama_func.py
@@ -19,7 +19,7 @@ from modules.utils import *
 def get_index_name(file_src):
     index_name = []
     for file in file_src:
-        index_name.append(os.path.basename(file.name))
+        index_name.append(file.name)
     index_name = sorted(index_name)
     index_name = "".join(index_name)
     index_name = sha1sum(index_name)


### PR DESCRIPTION
# 描述
这里不能用os.path.basename(file.name)
因为如果我修改该文件内容，文件名称一致，会导致用同一个索引。
而 file.name ，gradio对修改过的文件在内存中的地址会变。
也许改成：        index_name += file.name

# 补充信息
如果你有其他的考虑，可以忽略这个PR😊