### PR TITLE
feat: show initial geoip with given proxy settings

### DIFF
--- a/modules/utils.py
+++ b/modules/utils.py
@@ -374,7 +374,8 @@ def replace_today(prompt):
 
 def get_geoip():
     try:
-        response = requests.get("https://ipapi.co/json/", timeout=5)
+        with retrieve_proxy():
+            response = requests.get("https://ipapi.co/json/", timeout=5)
         data = response.json()
     except:
         data = {"error": True, "reason": "连接ipapi失败"}


### PR DESCRIPTION
<!--
这是一个拉取请求模板。本文段处于注释中，请您先查看本注释，在您提交时该段文字将不会显示。

1. 在提交拉取请求前，您最好已经查看过：https://github.com/GaiZhenbiao/ChuanhuChatGPT/wiki/贡献指南 了解了我们的大致要求；
2. 如果您的这一个pr包含多个不同的功能添加或问题修复，请务必将您的提交拆分为多个不同的原子化的commit，甚至您可以在不同的分支中提交多个pull request；
3. 不过，就算您的提交与pr写得完全不合规范也没有关系，您可以直接提交，我们会进行审查。总之我们欢迎您做出贡献！

您可以参考这个示例 pull request：[#439](https://github.com/GaiZhenbiao/ChuanhuChatGPT/pull/439)
-->

### 描述

在config.json已经提供了proxy设定时，在获取GeoIP时使用给定的proxy环境下的地理位置，而非用户全局环境下的地理位置

Before:
![image](https://user-images.githubusercontent.com/26458167/229289958-4bb23345-de3c-412f-9892-285997e0b858.png)

After:
![image](https://user-images.githubusercontent.com/26458167/229289849-b127c1b5-e6b8-4d30-9051-15d88b8cf553.png)


### 相关问题

在进入界面时，GeoIP的获取使用的是默认环境的ip地址，这样对于已经提供了proxy设置的用户来说是不准确的，因为在核心的[`get_response`](https://github.com/GaiZhenbiao/ChuanhuChatGPT/blob/b6c84da428df0a141d650a3e21fff7bdacb0cc80/modules/chat_func.py#L38)函数中使用的是由[`retrieve_proxy`](https://github.com/GaiZhenbiao/ChuanhuChatGPT/blob/b6c84da428df0a141d650a3e21fff7bdacb0cc80/modules/chat_func.py#L68)提供的http_proxy和https_proxy.

