### PR TITLE
feat: 增加多账号机制

### DIFF
--- a/ChuanhuChatbot.py
+++ b/ChuanhuChatbot.py
@@ -76,7 +76,10 @@ with gr.Blocks(css=customCSS, theme=small_and_beautiful_theme) as demo:
                         visible=not HIDE_MY_KEY,
                         label="API-Key",
                     )
-                    usageTxt = gr.Markdown("**发送消息** 或 **提交key** 以显示额度", elem_id="usage_display")
+                    if multi_api_key:
+                        usageTxt = gr.Markdown("多账号模式已开启，无需输入key，可直接开始对话", elem_id="usage_display")
+                    else:
+                        usageTxt = gr.Markdown("**发送消息** 或 **提交key** 以显示额度", elem_id="usage_display")
                     model_select_dropdown = gr.Dropdown(
                         label="选择模型", choices=MODELS, multiselect=False, value=MODELS[0]
                     )

--- a/config_example.json
+++ b/config_example.json
@@ -8,5 +8,11 @@
             "two_column": false,
             "formula_ocr": true
         }
-    }
+    },
+    "multi_api_key": false,
+    "api_key_list": [
+        "sk-xxxxxxxxxxxxxxxxxxxxxxxx1",
+        "sk-xxxxxxxxxxxxxxxxxxxxxxxx2",
+        "sk-xxxxxxxxxxxxxxxxxxxxxxxx3"
+    ]
 }

--- a/modules/chat_func.py
+++ b/modules/chat_func.py
@@ -35,6 +35,7 @@ initial_prompt = "You are a helpful assistant."
 HISTORY_DIR = "history"
 TEMPLATES_DIR = "templates"
 
+@shared.state.switching_api_key # 在不开启多账号模式的时候，这个装饰器不会起作用
 def get_response(
     openai_api_key, system_prompt, history, temperature, top_p, stream, selected_model
 ):
@@ -330,7 +331,7 @@ def predict(
     else:
         display_reference = ""
 
-    if len(openai_api_key) != 51:
+    if len(openai_api_key) != 51 and not shared.state.multi_api_key:
         status_text = standard_error_msg + no_apikey_msg
         logging.info(status_text)
         chatbot.append((inputs, ""))

--- a/modules/config.py
+++ b/modules/config.py
@@ -16,7 +16,8 @@ __all__ = [
     "retrieve_proxy",
     "log_level",
     "advance_docs",
-    "update_doc_config"
+    "update_doc_config",
+    "multi_api_key",
 ]
 
 # 添加一个统一的config文件，避免文件过多造成的疑惑（优先级最低）
@@ -35,6 +36,15 @@ if os.environ.get("dockerrun") == "yes":
 ## 处理 api-key 以及 允许的用户列表
 my_api_key = config.get("openai_api_key", "") # 在这里输入你的 API 密钥
 my_api_key = os.environ.get("my_api_key", my_api_key)
+
+## 多账户机制
+multi_api_key = config.get("multi_api_key", False) # 是否开启多账户机制
+if multi_api_key:
+    api_key_list = config.get("api_key_list", [])
+    if len(api_key_list) == 0:
+        logging.error("多账号模式已开启，但api_key_list为空，请检查config.json")
+        sys.exit(1)
+    shared.state.set_api_key_queue(api_key_list)
 
 auth_list = config.get("users", []) # 实际上是使用者的列表
 authflag = len(auth_list) > 0  # 是否开启认证的状态值，改为判断auth_list长度


### PR DESCRIPTION
<!--
这是一个拉取请求模板。本文段处于注释中，请您先查看本注释，在您提交时该段文字将不会显示。

1. 在提交拉取请求前，您最好已经查看过：https://github.com/GaiZhenbiao/ChuanhuChatGPT/wiki/贡献指南 了解了我们的大致要求；
2. 如果您的这一个pr包含多个不同的功能添加或问题修复，请务必将您的提交拆分为多个不同的原子化的commit，甚至您可以在不同的分支中提交多个pull request；
3. 不过，就算您的提交与pr写得完全不合规范也没有关系，您可以直接提交，我们会进行审查。总之我们欢迎您做出贡献！

您可以参考这个示例 pull request：[#439](https://github.com/GaiZhenbiao/ChuanhuChatGPT/pull/439)
-->

### 描述

增加了一个可选的多账号机制。通过较少的代码改动与以往的单账号机制兼容。

每次调用`get_response`会自动切换不同的key，且这种切换是线程安全的。

多账号机制的适用场景：通过多个免费账号同时为多人（例如，一个实验室的同学）提供服务，使服务的并发性不受到账号调用频率的限制。