### PR TITLE
解决Bug(‘str’ object has no attribute ‘api_key’)

### DIFF
--- a/modules/shared.py
+++ b/modules/shared.py
@@ -41,11 +41,11 @@ class State:
     def switching_api_key(self, func):
         if not hasattr(self, "api_key_queue"):
             return func
-        
+
         def wrapped(*args, **kwargs):
             api_key = self.api_key_queue.get()
-            args = list(args)[1:]
-            ret = func(api_key, *args, **kwargs)
+            args[0].api_key = api_key
+            ret = func(*args, **kwargs)
             self.api_key_queue.put(api_key)
             return ret
 


### PR DESCRIPTION
<!--
这是一个拉取请求模板。本文段处于注释中，请您先查看本注释，在您提交时该段文字将不会显示。

1. 在提交拉取请求前，您最好已经查看过：https://github.com/GaiZhenbiao/ChuanhuChatGPT/wiki/贡献指南 了解了我们的大致要求；
2. 如果您的这一个pr包含多个不同的功能添加或问题修复，请务必将您的提交拆分为多个不同的原子化的commit，甚至您可以在不同的分支中提交多个pull request；
3. 不过，就算您的提交与pr写得完全不合规范也没有关系，您可以直接提交，我们会进行审查。总之我们欢迎您做出贡献！

您可以参考这个示例 pull request：[#439](https://github.com/GaiZhenbiao/ChuanhuChatGPT/pull/439)
-->

### 描述

更正装饰器@shared.state.switching_api_key
解决装饰器返回值将self覆盖为api_key的问题
解决在多账号模式下的Bug(‘str’ object has no attribute ‘api_key’)
> before

![image](https://user-images.githubusercontent.com/58359492/230967979-8801d952-cbe8-47ca-be2c-1f28386453f5.png)

> after

![image](https://user-images.githubusercontent.com/58359492/230967670-eba57147-f61c-4af4-9e2a-528a0a1efe24.png)

### 相关问题

#584

