### PR TITLE
feat: 将ip/port/share这些跟launch有关的参数转移到config.json中

### DIFF
--- a/ChuanhuChatbot.py
+++ b/ChuanhuChatbot.py
@@ -431,35 +431,15 @@ demo.title = "川虎ChatGPT 🚀"
 
 if __name__ == "__main__":
     reload_javascript()
-    # if running in Docker
-    if dockerflag:
-        if authflag:
-            demo.queue(concurrency_count=CONCURRENT_COUNT).launch(
-                server_name="0.0.0.0",
-                server_port=7860,
-                auth=auth_list,
-                favicon_path="./assets/favicon.ico",
-            )
-        else:
-            demo.queue(concurrency_count=CONCURRENT_COUNT).launch(
-                server_name="0.0.0.0",
-                server_port=7860,
-                share=False,
-                favicon_path="./assets/favicon.ico",
-            )
-    # if not running in Docker
-    else:
-        if authflag:
-            demo.queue(concurrency_count=CONCURRENT_COUNT).launch(
-                share=False,
-                auth=auth_list,
-                favicon_path="./assets/favicon.ico",
-                inbrowser=True,
-            )
-        else:
-            demo.queue(concurrency_count=CONCURRENT_COUNT).launch(
-                share=False, favicon_path="./assets/favicon.ico", inbrowser=True
-            )  # 改为 share=True 可以创建公开分享链接
-        # demo.queue(concurrency_count=CONCURRENT_COUNT).launch(server_name="0.0.0.0", server_port=7860, share=False) # 可自定义端口
-        # demo.queue(concurrency_count=CONCURRENT_COUNT).launch(server_name="0.0.0.0", server_port=7860,auth=("在这里填写用户名", "在这里填写密码")) # 可设置用户名与密码
-        # demo.queue(concurrency_count=CONCURRENT_COUNT).launch(auth=("在这里填写用户名", "在这里填写密码")) # 适合Nginx反向代理
+    auth = auth_list if authflag else None
+    demo.queue(concurrency_count=CONCURRENT_COUNT).launch(
+        server_name=server_name,
+        server_port=server_port,
+        share=share,
+        auth=auth_list,
+        favicon_path="./assets/favicon.ico",
+        inbrowser=not dockerflag, # 禁止在docker下开启inbrowser
+    )
+    # demo.queue(concurrency_count=CONCURRENT_COUNT).launch(server_name="0.0.0.0", server_port=7860, share=False) # 可自定义端口
+    # demo.queue(concurrency_count=CONCURRENT_COUNT).launch(server_name="0.0.0.0", server_port=7860,auth=("在这里填写用户名", "在这里填写密码")) # 可设置用户名与密码
+    # demo.queue(concurrency_count=CONCURRENT_COUNT).launch(auth=("在这里填写用户名", "在这里填写密码")) # 适合Nginx反向代理

--- a/config_example.json
+++ b/config_example.json
@@ -20,5 +20,10 @@
         "sk-xxxxxxxxxxxxxxxxxxxxxxxx1",
         "sk-xxxxxxxxxxxxxxxxxxxxxxxx2",
         "sk-xxxxxxxxxxxxxxxxxxxxxxxx3"
-    ]
+    ],
+    // 如果使用自定义端口、自定义ip，请取消注释并替换对应内容
+    // "server_name": "0.0.0.0",
+    // "server_port": 7860,
+    // 如果要share到gradio，设置为true
+    // "share": false,
 }

--- a/modules/config.py
+++ b/modules/config.py
@@ -18,6 +18,9 @@ __all__ = [
     "advance_docs",
     "update_doc_config",
     "multi_api_key",
+    "server_name",
+    "server_port",
+    "share",
 ]
 
 # 添加一个统一的config文件，避免文件过多造成的疑惑（优先级最低）
@@ -148,3 +151,19 @@ def update_doc_config(two_column_pdf):
     advance_docs["pdf"]["two_column"] = two_column_pdf
 
     logging.info(f"更新后的文件参数为：{advance_docs}")
+
+## 处理gradio.launch参数
+server_name = config.get("server_name", None)
+server_port = config.get("server_port", None)
+if server_name is None:
+    if dockerflag:
+        server_name = "0.0.0.0"
+    else:
+        server_name = "127.0.0.1"
+if server_port is None:
+    if dockerflag:
+        server_port = 7860
+
+assert server_port is None or type(server_port) == int, "要求port设置为int类型"
+
+share = config.get("share", False)


### PR DESCRIPTION
### 描述

将ip/port/share这些跟launch有关的参数转移到config.json中

### 相关问题

避免在每次更新repo之后，必须重新设置一次servername,port参数

参考 [#599 ](https://github.com/GaiZhenbiao/ChuanhuChatGPT/pull/595) 将debug模式下的port设置为None，可以自动分配