### PR TITLE
fix: 指定 httpx 版本到 0.23.3

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -15,3 +15,4 @@ pdfplumber
 pandas
 commentjson
 openpyxl
+httpx==0.23.3


### PR DESCRIPTION
<!--
这是一个拉取请求模板。本文段处于注释中，请您先查看本注释，在您提交时该段文字将不会显示。

1. 在提交拉取请求前，您最好已经查看过：https://github.com/GaiZhenbiao/ChuanhuChatGPT/wiki/贡献指南 了解了我们的大致要求；
2. 如果您的这一个pr包含多个不同的功能添加或问题修复，请务必将您的提交拆分为多个不同的原子化的commit，甚至您可以在不同的分支中提交多个pull request；
3. 不过，就算您的提交与pr写得完全不合规范也没有关系，您可以直接提交，我们会进行审查。总之我们欢迎您做出贡献！

您可以参考这个示例 pull request：[#439](https://github.com/GaiZhenbiao/ChuanhuChatGPT/pull/439)
-->

### 描述
默认安装最新版本`httpx==0.24.0`，并且设置了环境变量 `NO_PROXY=::1`时， import gradio会报错
<img width="916" alt="image" src="https://user-images.githubusercontent.com/159480/232266048-266f4a4f-ec3d-4890-8041-c5e2fceea1bd.png">
<img width="606" alt="image" src="https://user-images.githubusercontent.com/159480/232266063-aa1781a9-9c99-47b0-a61b-349b63da4fe4.png">


### 相关问题
指定httpx版本到0.23.3后程序正常启动

### 补充信息
https://github.com/encode/httpx/pull/2659

#### 开发进度

- [x] 指定httpx 版本到 0.23.3