### PR TITLE
解决上传对话json文件后报错

### DIFF
--- a/ChuanhuChatbot.py
+++ b/ChuanhuChatbot.py
@@ -168,7 +168,10 @@ with gr.Blocks(css=customCSS, theme=small_and_beautiful_theme) as demo:
                                     gr.Markdown(i18n("默认保存于history文件夹"))
                             with gr.Row():
                                 with gr.Column():
-                                    downloadFile = gr.File(interactive=True)
+                                    chat_history_files = gr.File(label=i18n("上传历史对话"), type="file")
+                            with gr.Row():
+                                with gr.Column():
+                                    downloadFile = gr.File(interactive=False, label=i18n("文件下载"))
 
                 with gr.Tab(label=i18n("高级")):
                     gr.Markdown(i18n("# ⚠️ 务必谨慎更改 ⚠️\n\n如果无法使用请恢复默认设置"))
@@ -330,7 +333,8 @@ with gr.Blocks(css=customCSS, theme=small_and_beautiful_theme) as demo:
     submitBtn.click(**get_usage_args)
 
     index_files.change(handle_file_upload, [current_model, index_files, chatbot], [index_files, chatbot, status_display])
-
+    chat_history_files.change(handle_chat_history_upload, [current_model, chat_history_files, chatbot, user_name])
+    
     emptyBtn.click(
         reset,
         inputs=[current_model],

--- a/modules/models/base_model.py
+++ b/modules/models/base_model.py
@@ -552,7 +552,7 @@ class BaseLLMModel:
             logging.debug(f"{user_name} 加载对话历史完毕")
             self.history = json_s["history"]
             return filename, json_s["system"], json_s["chatbot"]
-        except FileNotFoundError:
+        except (FileNotFoundError,IsADirectoryError):
             logging.warning(f"{user_name} 没有找到对话历史文件，不执行任何操作")
             return filename, self.system_prompt, chatbot
 

--- a/modules/utils.py
+++ b/modules/utils.py
@@ -13,6 +13,9 @@ import html
 import sys
 import subprocess
 
+from uuid import uuid4
+import shutil
+
 import gradio as gr
 from pypinyin import lazy_pinyin
 import tiktoken
@@ -112,6 +115,15 @@ def set_single_turn(current_model, *args):
 
 def handle_file_upload(current_model, *args):
     return current_model.handle_file_upload(*args)
+
+def handle_chat_history_upload(current_model, tmp_file, chatbot, username):
+    if tmp_file is None:
+        return
+    history_name = os.path.basename(tmp_file.name)
+    if os.path.exists(os.path.join(HISTORY_DIR, username, history_name)):
+        basename, extension = os.path.splitext(history_name)
+        history_name = basename + '-' + str(uuid4())[0:8] + extension
+    shutil.copyfile(tmp_file.name, os.path.join(HISTORY_DIR, username, history_name))
 
 def like(current_model, *args):
     return current_model.like(*args)


### PR DESCRIPTION
我也遇到了这个问题，相同的issue在这里：[https://github.com/GaiZhenbiao/ChuanhuChatGPT/issues/607](https://github.com/GaiZhenbiao/ChuanhuChatGPT/issues/607)

1. 上传的json如果同名，会重新添加随机后缀后保存
2. 上传成功后，需要点击刷新按钮才能看到
3. 对界面的元素进行了微小修改，增加了新的记录上传按钮，修改了原来的上传按钮