### PR TITLE
修正没有自动创建用户专属 history 目录，导致加载历史对话记录报错的问题

### DIFF
--- a/modules/utils.py
+++ b/modules/utils.py
@@ -580,6 +580,8 @@ def get_latest_filepath(dirname):
 
 def get_history_filepath(username):
     dirname = os.path.join(HISTORY_DIR, username)
+    if not os.path.exists(dirname):
+        os.makedirs(dirname)
     latest_file = get_latest_filepath(dirname)
     if not latest_file:
         latest_file = new_auto_history_filename(dirname)


### PR DESCRIPTION
<!--
这是一个拉取请求模板。本文段处于注释中，请您先查看本注释，在您提交时该段文字将不会显示。

1. 在提交拉取请求前，您最好已经查看过：https://github.com/GaiZhenbiao/ChuanhuChatGPT/wiki/贡献指南 了解了我们的大致要求；
2. 如果您的这一个pr包含多个不同的功能添加或问题修复，请务必将您的提交拆分为多个不同的原子化的commit，甚至您可以在不同的分支中提交多个pull request；
3. 不过，就算您的提交与pr写得完全不合规范也没有关系，您可以直接提交，我们会进行审查。总之我们欢迎您做出贡献！

您可以参考这个示例 pull request：[#439](https://github.com/GaiZhenbiao/ChuanhuChatGPT/pull/439)
-->

### 描述

增加了用户专属历史记录目录的判断逻辑，如果不存在则自动创建。

### 相关问题

在使用用户名和密码登录后，由于系统找不到对应的用户历史记录会报错

<img width="1617" alt="CleanShot 2023-05-01 at 21 46 22@2x" src="https://user-images.githubusercontent.com/5654585/235460543-58be7805-9118-4e84-ba5d-db790a822362.png">

增加了判断逻辑之后，如果用户历史记录目录不存在，则自动创建。

### 补充信息

此前的版本中不存在这个问题，不确定从什么版本开始实现的，我检查了我的运行环境，这个 Bug 可以复现。
