### PR TITLE
优化 Dockerfile 大幅减少镜像体积

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,18 @@
-FROM python:3.9 as builder
-RUN apt-get update && apt-get install -y build-essential
+FROM python:3.9-slim-buster as builder
+RUN apt-get update \
+    && apt-get install -y build-essential \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
 COPY requirements.txt .
 COPY requirements_advanced.txt .
-RUN pip install --user -r requirements.txt
-# RUN pip install --user -r requirements_advanced.txt
+RUN pip install --user --no-cache-dir -r requirements.txt
+# RUN pip install --user --no-cache-dir -r requirements_advanced.txt
 
-FROM python:3.9
-MAINTAINER iskoldt
+FROM python:3.9-slim-buster
+LABEL maintainer="iskoldt"
 COPY --from=builder /root/.local /root/.local
 ENV PATH=/root/.local/bin:$PATH
 COPY . /app
 WORKDIR /app
-ENV dockerrun yes
-CMD ["python3", "-u", "ChuanhuChatbot.py", "2>&1", "|", "tee", "/var/log/application.log"]
+ENV dockerrun=yes
+CMD ["python3", "-u", "ChuanhuChatbot.py","2>&1", "|", "tee", "/var/log/application.log"]


### PR DESCRIPTION
<!--
这是一个拉取请求模板。本文段处于注释中，请您先查看本注释，在您提交时该段文字将不会显示。

1. 在提交拉取请求前，您最好已经查看过：https://github.com/GaiZhenbiao/ChuanhuChatGPT/wiki/贡献指南 了解了我们的大致要求；
2. 如果您的这一个pr包含多个不同的功能添加或问题修复，请务必将您的提交拆分为多个不同的原子化的commit，甚至您可以在不同的分支中提交多个pull request；
3. 不过，就算您的提交与pr写得完全不合规范也没有关系，您可以直接提交，我们会进行审查。总之我们欢迎您做出贡献！

您可以参考这个示例 pull request：[#439](https://github.com/GaiZhenbiao/ChuanhuChatGPT/pull/439)
-->

### 描述

用 GPT-4 优化了一下 Dockerfile，生成的 amd64 平台的 image 的体积减小了大约 50%

<img width="623" alt="CleanShot 2023-05-04 at 11 32 43@2x" src="https://user-images.githubusercontent.com/5654585/236107037-133f3378-7a66-44ed-bc31-9777a7cd24ff.png">


### 相关问题

经过在自行部署的平台上的测试，暂未发现问题
