### PR TITLE
feat: 将引用网站改为气泡形式

### DIFF
--- a/assets/custom.css
+++ b/assets/custom.css
@@ -230,7 +230,8 @@ hr.append-display {
     padding: 0.5em;
     text-align: center;
     text-overflow: ellipsis;
-    /* overflow: hidden; */
+    overflow: hidden;
+    min-width: 20%;
     white-space: nowrap;
     margin: 0.2rem 0.1rem;
     text-decoration: none !important;

--- a/assets/custom.css
+++ b/assets/custom.css
@@ -204,6 +204,42 @@ input[type=range]::-webkit-slider-runnable-track {
     background: transparent;
 }
 
+hr.append-display {
+    margin: 8px 0;
+    border: none;
+    height: 1px;
+    border-top-width: 0;
+    background-image: linear-gradient(to right, rgba(50,50,50, 0.1), rgba(150, 150, 150, 0.8), rgba(50,50,50, 0.1));
+}
+.source-a {
+    font-size: 0.8em;
+    max-width: 100%;
+    margin: 0;
+    display: inline-flex;
+    flex-direction: row;
+    flex-wrap: nowrap;
+    align-items: center;
+    /* background-color: #dddddd88; */
+    border-radius: 1.5rem;
+    padding: 0.2em;
+}
+.source-a a {
+    display: inline-block;
+    background-color: #aaaaaa50;
+    border-radius: 1rem;
+    padding: 0.5em;
+    text-overflow: ellipsis;
+    overflow: hidden;
+    white-space: nowrap;
+    margin: 0.1rem;
+    text-decoration: none !important;
+    transition: flex 0.5s;
+}
+.source-a a:hover {
+    background-color: #aaaaaa20;
+    flex: none;
+}
+
 #submit_btn, #cancel_btn {
     height: 42px !important;
 }

--- a/assets/custom.css
+++ b/assets/custom.css
@@ -215,9 +215,9 @@ hr.append-display {
     font-size: 0.8em;
     max-width: 100%;
     margin: 0;
-    display: inline-flex;
+    display: flex;
     flex-direction: row;
-    flex-wrap: nowrap;
+    flex-wrap: wrap;
     align-items: center;
     /* background-color: #dddddd88; */
     border-radius: 1.5rem;
@@ -228,16 +228,18 @@ hr.append-display {
     background-color: #aaaaaa50;
     border-radius: 1rem;
     padding: 0.5em;
+    text-align: center;
     text-overflow: ellipsis;
-    overflow: hidden;
+    /* overflow: hidden; */
     white-space: nowrap;
-    margin: 0.1rem;
+    margin: 0.2rem 0.1rem;
     text-decoration: none !important;
+    flex: 1;
     transition: flex 0.5s;
 }
 .source-a a:hover {
     background-color: #aaaaaa20;
-    flex: none;
+    flex: 2;
 }
 
 #submit_btn, #cancel_btn {

--- a/modules/models/base_model.py
+++ b/modules/models/base_model.py
@@ -246,7 +246,7 @@ class BaseLLMModel:
         stream_iter = self.get_answer_stream_iter()
 
         if display_append:
-            display_append = "<hr>" +display_append
+            display_append = '\n\n<hr class="append-display no-in-raw" />' + display_append
         for partial_text in stream_iter:
             chatbot[-1] = (chatbot[-1][0], partial_text + display_append)
             self.all_token_counts[-1] += 1
@@ -348,10 +348,11 @@ class BaseLLMModel:
                 reference_results.append([result['body'], result['href']])
                 display_append.append(
                     # f"{idx+1}. [{domain_name}]({result['href']})\n"
-                    f"<li><a href=\"{result['href']}\" target=\"_blank\">{result['title']}</a></li>\n"
+                    f"<a href=\"{result['href']}\" target=\"_blank\">{idx+1}.&nbsp;{result['title']}</a>"
                 )
             reference_results = add_source_numbers(reference_results)
-            display_append = "<ol>\n\n" + "".join(display_append) + "</ol>"
+            # display_append = "<ol>\n\n" + "".join(display_append) + "</ol>"
+            display_append = '<div class = "source-a">' + "".join(display_append) + '</div>'
             real_inputs = (
                 replace_today(WEBSEARCH_PTOMPT_TEMPLATE)
                 .replace("{query}", real_inputs)

--- a/modules/utils.py
+++ b/modules/utils.py
@@ -256,7 +256,8 @@ def escape_markdown(text):
         '`': '&#96;',
         '>': '&#62;',
         '<': '&#60;',
-        '|': '&#124;'
+        '|': '&#124;',
+        ':': '&#58;',
     }
     return ''.join(escape_chars.get(c, c) for c in text)
 

--- a/modules/utils.py
+++ b/modules/utils.py
@@ -214,7 +214,10 @@ def convert_bot_before_marked(chat_message):
         non_code_parts = code_block_pattern.split(chat_message)[::2]
         result = []
 
-        raw = f'<div class="raw-message hideM">{escape_markdown(chat_message)}</div>'
+        hr_pattern = r'\n\n<hr class="append-display no-in-raw" />(.*?)'
+        hr_match = re.search(hr_pattern, chat_message, re.DOTALL)
+        clip_hr = chat_message[:hr_match.start()] if hr_match else chat_message
+        raw = f'<div class="raw-message hideM">{escape_markdown(clip_hr)}</div>'
         for non_code, code in zip(non_code_parts, code_blocks + [""]):
             if non_code.strip():
                 result.append(non_code)


### PR DESCRIPTION
## 作者自述
### 描述
1. 更改了分割线样式
2. 将引用网站改为气泡形式，且在鼠标悬浮时有展开动画
3. 在raw-message中不显示display_append

![iShot_2023-06-14_下午1 55 47](https://github.com/GaiZhenbiao/ChuanhuChatGPT/assets/23137268/2f394dfd-6bd9-4edf-9fab-90c24ff915f1)

### 相关问题
无

### 补充信息
**Known Issue:**
- [x] ~~raw-message中引用来源的一个`]`会被错误地escape（并非由此PR引入）~~ (fixed)

<!-- 写明开发进度的例子： WIP EXAMPLE:

#### 开发进度
- [x] 已经做好的事情1
- [ ] 还要干的事情1
- [ ] 还要干的事情2

-->

<!-- ############ Copilot for pull request ############
     不要删除下面的内容！ DO NOT DELETE THE CONTENT BELOW! 
-->
## Copilot4PR
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 6226058</samp>

### Summary
🎨🗑️🔗

<!--
1.  🎨 - This emoji can be used to represent the change that adds some custom CSS styles for the `<hr>` element and the `<a>` elements inside a `<div class="source-a">` element. This emoji conveys the idea of improving the appearance and design of the web search results.
2.  🗑️ - This emoji can be used to represent the change that modifies the `convert_bot_before_marked` function in the `utils.py` module. This emoji conveys the idea of removing or deleting something that is not needed or relevant for the raw message.
3.  🔗 - This emoji can be used to represent the change that modifies the `display_append` variable in two classes of the `base_model.py` file to use custom CSS styles and `<div>` and `<a>` elements for displaying web search results in the chatbot input. This emoji conveys the idea of adding or using links or references for the web search feature.
-->
The pull request enhances the web search feature of the chatbot by adding custom CSS styles and HTML elements to display the search results as sources for the chatbot responses. It also removes the search results from the raw message view to avoid confusion. The changes affect the `base_model.py`, `custom.css`, and `utils.py` files.

> _Oh we're the crew of the chatbot ship, and we work with code and style_
> _We make the web search look so slick, with our `CSS` and `div` and `a`_
> _But when the user wants to see the raw, we strip the `hr` and the source away_
> _So heave away, me hearties, heave away, on the count of one, two, three_

### Walkthrough
*  Add custom CSS styles for web search results in `assets/custom.css` ([link](https://github.com/GaiZhenbiao/ChuanhuChatGPT/pull/806/files?diff=unified&w=0#diff-baa36c5725f9982493081d3f0134b0d49b03ec520cd211243a7b3a24fe7825d6R207-R245))
*  Use custom CSS styles and `<a>` elements to append web search results to chatbot input in `base_model.py` ([link](https://github.com/GaiZhenbiao/ChuanhuChatGPT/pull/806/files?diff=unified&w=0#diff-3ca0698dd4eab37da223f4972bcf159dcc951ce059737efc0663d44a1a214b06L249-R249), [link](https://github.com/GaiZhenbiao/ChuanhuChatGPT/pull/806/files?diff=unified&w=0#diff-3ca0698dd4eab37da223f4972bcf159dcc951ce059737efc0663d44a1a214b06L351-R355))
*  Remove `<hr>` element and web search results from raw message in `utils.py` ([link](https://github.com/GaiZhenbiao/ChuanhuChatGPT/pull/806/files?diff=unified&w=0#diff-875600658966e53900b1b063d3f37d175ba9f9fffee31acfce3f8de15b75df72L217-R220))

