### PR TITLE
解决内网访问点击复制按钮失效

### DIFF
--- a/assets/custom.js
+++ b/assets/custom.js
@@ -373,19 +373,38 @@ function addChuanhuButton(botElement) {
     copyButton.classList.add('copy-bot-btn');
     copyButton.setAttribute('aria-label', 'Copy');
     copyButton.innerHTML = copyIcon;
-    copyButton.addEventListener('click', () => {
+    copyButton.addEventListener('click', async () => {
         const textToCopy = rawMessage.innerText;
-        navigator.clipboard
-            .writeText(textToCopy)
-            .then(() => {
+
+        try {
+            if ("clipboard" in navigator) {
+                await navigator.clipboard.writeText(textToCopy);
                 copyButton.innerHTML = copiedIcon;
                 setTimeout(() => {
                     copyButton.innerHTML = copyIcon;
                 }, 1500);
-            })
-            .catch(() => {
-                console.error("copy failed");
-            });
+            } else {
+                const textArea = document.createElement("textarea");
+                textArea.value = textToCopy;
+
+                document.body.appendChild(textArea);
+                textArea.select();
+
+                try {
+                    document.execCommand('copy');
+                    copyButton.innerHTML = copiedIcon;
+                    setTimeout(() => {
+                        copyButton.innerHTML = copyIcon;
+                    }, 1500);
+                } catch (error) {
+                    console.error("Copy failed: ", error);
+                }
+
+                document.body.removeChild(textArea);
+            }
+        } catch (error) {
+            console.error("Copy failed: ", error);
+        }
     });
     botElement.appendChild(copyButton);
 


### PR DESCRIPTION
## 作者自述
### 描述
解决内网访问时，点击复制按钮没有效果
![2023-07-02 17 46 40](https://github.com/GaiZhenbiao/ChuanhuChatGPT/assets/46100050/81c52958-4cd5-4c27-b5c0-e54f54c43fd9)


### 相关问题
（如有）请列出与此拉取请求相关的issue。

https://github.com/GaiZhenbiao/ChuanhuChatGPT/issues/826.   解决这个issues



-->
## Copilot4PR
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 3fa4fd7</samp>

### Summary
📋🔧🚀

<!--
1.  📋 - This emoji represents the clipboard feature and the main functionality of the button.
2.  🔧 - This emoji represents the improvement and modification of the code and the fallback method.
3.  🚀 - This emoji represents the use of the `async/await` syntax and the enhanced performance and user experience of the button.
-->
Improved the copy feature in `assets/custom.js` by adding a fallback method for browsers that do not support the `navigator.clipboard` API and using `async/await` syntax for error handling.

> _`addChuanhuButton`_
> _now copies with fallback method_
> _no more clipboard woes_

### Walkthrough
* Improve the copy feature of the Chuanhu button by using a fallback method for browsers that do not support the `navigator.clipboard` API ([link](https://github.com/GaiZhenbiao/ChuanhuChatGPT/pull/827/files?diff=unified&w=0#diff-b2ea2e58a49cde926ae8ec64097108d3e38fea50eb5183b7770cec44dddad9d5L376-R407) in `assets/custom.js`)

