### PR TITLE
feat: add mj image generation support through proxy api

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -145,3 +145,4 @@ lora/
 .idea
 templates/*
 files/
+tmp/

--- a/config_example.json
+++ b/config_example.json
@@ -7,6 +7,11 @@
     "xmchat_api_key": "", // 你的 xmchat API Key，用于 XMChat 对话模型
     "minimax_api_key": "", // 你的 MiniMax API Key，用于 MiniMax 对话模型
     "minimax_group_id": "", // 你的 MiniMax Group ID，用于 MiniMax 对话模型
+    "midjourney_proxy_api_base": "https://xxx/mj", // 你的 https://github.com/novicezk/midjourney-proxy 代理地址
+    "midjourney_proxy_api_secret": "", // 你的 MidJourney Proxy API Secret，用于鉴权访问 api，可选
+    "midjourney_discord_proxy_url": "", // 你的 MidJourney Discord Proxy URL，用于对生成对图进行反代，可选
+    "midjourney_temp_folder": "./tmp", // 你的 MidJourney 临时文件夹，用于存放生成的图片，填空则关闭自动下载切图（直接显示MJ的四宫格图）
+
 
     //== Azure ==
     "openai_api_type": "openai", // 可选项：azure, openai

--- a/modules/config.py
+++ b/modules/config.py
@@ -114,6 +114,15 @@ os.environ["MINIMAX_API_KEY"] = minimax_api_key
 minimax_group_id = config.get("minimax_group_id", "")
 os.environ["MINIMAX_GROUP_ID"] = minimax_group_id
 
+midjourney_proxy_api_base = config.get("midjourney_proxy_api_base", "")
+os.environ["MIDJOURNEY_PROXY_API_BASE"] = midjourney_proxy_api_base
+midjourney_proxy_api_secret = config.get("midjourney_proxy_api_secret", "")
+os.environ["MIDJOURNEY_PROXY_API_SECRET"] = midjourney_proxy_api_secret
+midjourney_discord_proxy_url = config.get("midjourney_discord_proxy_url", "")
+os.environ["MIDJOURNEY_DISCORD_PROXY_URL"] = midjourney_discord_proxy_url
+midjourney_temp_folder = config.get("midjourney_temp_folder", "")
+os.environ["MIDJOURNEY_TEMP_FOLDER"] = midjourney_temp_folder
+
 load_config_to_environ(["openai_api_type", "azure_openai_api_key", "azure_openai_api_base_url",
                        "azure_openai_api_version", "azure_deployment_name", "azure_embedding_deployment_name", "azure_embedding_model_name"])
 

--- a/modules/models/base_model.py
+++ b/modules/models/base_model.py
@@ -169,7 +169,7 @@ class ModelType(Enum):
             model_type = ModelType.GooglePaLM
         elif "midjourney" in model_name_lower:
             model_type = ModelType.Midjourney
-        elif "azure" or "api" in model_name_lower:
+        elif "azure" in model_name_lower or "api" in model_name_lower:
             model_type = ModelType.LangchainChat
         else:
             model_type = ModelType.Unknown

--- a/modules/models/base_model.py
+++ b/modules/models/base_model.py
@@ -141,6 +141,7 @@ class ModelType(Enum):
     ChuanhuAgent = 8
     GooglePaLM = 9
     LangchainChat = 10
+    Midjourney = 11
 
     @classmethod
     def get_type(cls, model_name: str):
@@ -166,7 +167,9 @@ class ModelType(Enum):
             model_type = ModelType.ChuanhuAgent
         elif "palm" in model_name_lower:
             model_type = ModelType.GooglePaLM
-        elif "azure" in model_name_lower or "api" in model_name_lower:
+        elif "midjourney" in model_name_lower:
+            model_type = ModelType.Midjourney
+        elif "azure" or "api" in model_name_lower:
             model_type = ModelType.LangchainChat
         else:
             model_type = ModelType.Unknown

--- a/modules/models/midjourney.py
+++ b/modules/models/midjourney.py
@@ -1,0 +1,385 @@
+import base64
+import io
+import json
+import logging
+import pathlib
+import time
+import tempfile
+import os
+
+from datetime import datetime
+
+import requests
+import tiktoken
+from PIL import Image
+
+from modules.config import retrieve_proxy
+from modules.models.models import XMChat
+
+mj_proxy_api_base = os.getenv("MIDJOURNEY_PROXY_API_BASE")
+mj_discord_proxy_url = os.getenv("MIDJOURNEY_DISCORD_PROXY_URL")
+mj_temp_folder = os.getenv("MIDJOURNEY_TEMP_FOLDER")
+
+
+class Midjourney_Client(XMChat):
+
+    class FetchDataPack:
+        """
+        A class to store data for current fetching data from Midjourney API
+        """
+
+        action: str  # current action, e.g. "IMAGINE", "UPSCALE", "VARIATION"
+        prefix_content: str  # prefix content, task description and process hint
+        task_id: str  # task id
+        start_time: float  # task start timestamp
+        timeout: int  # task timeout in seconds
+        finished: bool  # whether the task is finished
+        prompt: str  # prompt for the task
+
+        def __init__(self, action, prefix_content, task_id, timeout=900):
+            self.action = action
+            self.prefix_content = prefix_content
+            self.task_id = task_id
+            self.start_time = time.time()
+            self.timeout = timeout
+            self.finished = False
+
+    def __init__(self, model_name, api_key, user_name=""):
+        super().__init__(api_key, user_name)
+        self.model_name = model_name
+        self.history = []
+        self.api_key = api_key
+        self.headers = {
+            "Content-Type": "application/json",
+            "mj-api-secret": f"{api_key}"
+        }
+        self.proxy_url = mj_proxy_api_base
+        self.command_splitter = "::"
+
+        if mj_temp_folder:
+            temp = "./tmp"
+            if user_name:
+                temp = os.path.join(temp, user_name)
+            if not os.path.exists(temp):
+                os.makedirs(temp)
+            self.temp_path = tempfile.mkdtemp(dir=temp)
+            logging.info("mj temp folder: " + self.temp_path)
+        else:
+            self.temp_path = None
+
+    def use_mj_self_proxy_url(self, img_url):
+        """
+        replace discord cdn url with mj self proxy url
+        """
+        return img_url.replace(
+            "https://cdn.discordapp.com/",
+            mj_discord_proxy_url and mj_discord_proxy_url or "https://cdn.discordapp.com/"
+        )
+
+    def split_image(self, image_url):
+        """
+        when enabling temp dir, split image into 4 parts
+        """
+        with retrieve_proxy():
+            image_bytes = requests.get(image_url).content
+        img = Image.open(io.BytesIO(image_bytes))
+        width, height = img.size
+        # calculate half width and height
+        half_width = width // 2
+        half_height = height // 2
+        # create coordinates (top-left x, top-left y, bottom-right x, bottom-right y)
+        coordinates = [(0, 0, half_width, half_height),
+                       (half_width, 0, width, half_height),
+                       (0, half_height, half_width, height),
+                       (half_width, half_height, width, height)]
+
+        images = [img.crop(c) for c in coordinates]
+        return images
+
+    def auth_mj(self):
+        """
+        auth midjourney api
+        """
+        # TODO: check if secret is valid
+        return {'status': 'ok'}
+
+    def request_mj(self, path: str, action: str, data: str, retries=3):
+        """
+        request midjourney api
+        """
+        mj_proxy_url = self.proxy_url
+        if mj_proxy_url is None or not (mj_proxy_url.startswith("http://") or mj_proxy_url.startswith("https://")):
+            raise Exception('please set MIDJOURNEY_PROXY_API_BASE in ENV or in config.json')
+
+        auth_ = self.auth_mj()
+        if auth_.get('error'):
+            raise Exception('auth not set')
+
+        fetch_url = f"{mj_proxy_url}/{path}"
+        # logging.info(f"[MJ Proxy] {action} {fetch_url} params: {data}")
+
+        for _ in range(retries):
+            try:
+                with retrieve_proxy():
+                    res = requests.request(method=action, url=fetch_url, headers=self.headers, data=data)
+                break
+            except Exception as e:
+                print(e)
+
+        if res.status_code != 200:
+            raise Exception(f'{res.status_code} - {res.content}')
+
+        return res
+
+    def fetch_status(self, fetch_data: FetchDataPack):
+        """
+        fetch status of current task
+        """
+        if fetch_data.start_time + fetch_data.timeout < time.time():
+            fetch_data.finished = True
+            return "任务超时，请检查 dc 输出。描述：" + fetch_data.prompt
+
+        time.sleep(3)
+        status_res = self.request_mj(f"task/{fetch_data.task_id}/fetch", "GET", '')
+        status_res_json = status_res.json()
+        if not (200 <= status_res.status_code < 300):
+            raise Exception("任务状态获取失败：" + status_res_json.get(
+                'error') or status_res_json.get('description') or '未知错误')
+        else:
+            fetch_data.finished = False
+            if status_res_json['status'] == "SUCCESS":
+                content = status_res_json['imageUrl']
+                fetch_data.finished = True
+            elif status_res_json['status'] == "FAILED":
+                content = status_res_json['failReason'] or '未知原因'
+                fetch_data.finished = True
+            elif status_res_json['status'] == "NOT_START":
+                content = f'任务未开始，已等待 {time.time() - fetch_data.start_time:.2f} 秒'
+            elif status_res_json['status'] == "IN_PROGRESS":
+                content = '任务正在运行'
+                if status_res_json.get('progress'):
+                    content += f"，进度：{status_res_json['progress']}"
+            elif status_res_json['status'] == "SUBMITTED":
+                content = '任务已提交处理'
+            elif status_res_json['status'] == "FAILURE":
+                fetch_data.finished = True
+                return "任务处理失败，原因：" + status_res_json['failReason'] or '未知原因'
+            else:
+                content = status_res_json['status']
+            if fetch_data.finished:
+                img_url = self.use_mj_self_proxy_url(status_res_json['imageUrl'])
+                if fetch_data.action == "DESCRIBE":
+                    return f"\n{status_res_json['prompt']}"
+                time_cost_str = f"\n\n{fetch_data.action} 花费时间：{time.time() - fetch_data.start_time:.2f} 秒"
+                upscale_str = ""
+                variation_str = ""
+                if fetch_data.action in ["IMAGINE", "UPSCALE", "VARIATION"]:
+                    upscale = [f'/mj UPSCALE{self.command_splitter}{i+1}{self.command_splitter}{fetch_data.task_id}'
+                               for i in range(4)]
+                    upscale_str = '\n放大图片：\n\n' + '\n\n'.join(upscale)
+                    variation = [f'/mj VARIATION{self.command_splitter}{i+1}{self.command_splitter}{fetch_data.task_id}'
+                                 for i in range(4)]
+                    variation_str = '\n图片变体：\n\n' + '\n\n'.join(variation)
+                if self.temp_path and fetch_data.action in ["IMAGINE", "VARIATION"]:
+                    try:
+                        images = self.split_image(img_url)
+                        # save images to temp path
+                        for i in range(4):
+                            images[i].save(pathlib.Path(self.temp_path) / f"{fetch_data.task_id}_{i}.png")
+                        img_str = '\n'.join(
+                            [f"![{fetch_data.task_id}](/file={self.temp_path}/{fetch_data.task_id}_{i}.png)"
+                             for i in range(4)])
+                        return fetch_data.prefix_content + f"{time_cost_str}\n\n{img_str}{upscale_str}{variation_str}"
+                    except Exception as e:
+                        logging.error(e)
+                return fetch_data.prefix_content + \
+                    f"{time_cost_str}[![{fetch_data.task_id}]({img_url})]({img_url}){upscale_str}{variation_str}"
+            else:
+                content = f"**任务状态:** [{(datetime.now()).strftime('%Y-%m-%d %H:%M:%S')}] - {content}"
+                content += f"\n\n花费时间：{time.time() - fetch_data.start_time:.2f} 秒"
+                if status_res_json['status'] == 'IN_PROGRESS' and status_res_json.get('imageUrl'):
+                    img_url = status_res_json.get('imageUrl')
+                    return f"{content}\n[![{fetch_data.task_id}]({img_url})]({img_url})"
+                return content
+        return None
+
+    def handle_file_upload(self, files, chatbot, language):
+        """
+        handle file upload
+        """
+        if files:
+            for file in files:
+                if file.name:
+                    logging.info(f"尝试读取图像: {file.name}")
+                    self.try_read_image(file.name)
+            if self.image_path is not None:
+                chatbot = chatbot + [((self.image_path,), None)]
+            if self.image_bytes is not None:
+                logging.info("使用图片作为输入")
+        return None, chatbot, None
+
+    def reset(self):
+        self.image_bytes = None
+        self.image_path = None
+        return [], "已重置"
+
+    def get_answer_at_once(self):
+        content = self.history[-1]['content']
+        answer = self.get_help()
+
+        if not content.lower().startswith("/mj"):
+            return answer, len(content)
+
+        prompt = content[3:].strip()
+        action = "IMAGINE"
+        first_split_index = prompt.find(self.command_splitter)
+        if first_split_index > 0:
+            action = prompt[:first_split_index]
+        if action not in ["IMAGINE", "DESCRIBE", "UPSCALE",
+                          # "VARIATION", "BLEND", "REROLL"
+                          ]:
+            raise Exception("任务提交失败：未知的任务类型")
+        else:
+            action_index = None
+            action_use_task_id = None
+            if action in ["VARIATION", "UPSCALE", "REROLL"]:
+                action_index = int(prompt[first_split_index + 2:first_split_index + 3])
+                action_use_task_id = prompt[first_split_index + 5:]
+
+            try:
+                res = None
+                if action == "IMAGINE":
+                    data = {
+                        "prompt": prompt
+                    }
+                    if self.image_bytes is not None:
+                        data["base64"] = 'data:image/png;base64,' + self.image_bytes
+                    res = self.request_mj("submit/imagine", "POST",
+                                          json.dumps(data))
+                elif action == "DESCRIBE":
+                    res = self.request_mj("submit/describe", "POST",
+                                          json.dumps({"base64": 'data:image/png;base64,' + self.image_bytes}))
+                elif action == "BLEND":
+                    res = self.request_mj("submit/blend", "POST", json.dumps(
+                        {"base64Array": [self.image_bytes, self.image_bytes]}))
+                elif action in ["UPSCALE", "VARIATION", "REROLL"]:
+                    res = self.request_mj(
+                        "submit/change", "POST",
+                        json.dumps({"action": action, "index": action_index, "taskId": action_use_task_id}))
+                res_json = res.json()
+                if not (200 <= res.status_code < 300) or (res_json['code'] not in [1, 22]):
+                    answer = "任务提交失败：" + res_json.get('error', res_json.get('description', '未知错误'))
+                else:
+                    task_id = res_json['result']
+                    prefix_content = f"**画面描述:** {prompt}\n**任务ID:** {task_id}\n"
+
+                    fetch_data = Midjourney_Client.FetchDataPack(
+                        action=action,
+                        prefix_content=prefix_content,
+                        task_id=task_id,
+                    )
+                    fetch_data.prompt = prompt
+                    while not fetch_data.finished:
+                        answer = self.fetch_status(fetch_data)
+            except Exception as e:
+                logging.error("submit failed", e)
+                answer = "任务提交错误：" + str(e.args[0]) if e.args else '未知错误'
+
+        return answer, tiktoken.get_encoding("cl100k_base").encode(content)
+
+    def get_answer_stream_iter(self):
+        content = self.history[-1]['content']
+        answer = self.get_help()
+
+        if not content.lower().startswith("/mj"):
+            yield answer
+            return
+
+        prompt = content[3:].strip()
+        action = "IMAGINE"
+        first_split_index = prompt.find(self.command_splitter)
+        if first_split_index > 0:
+            action = prompt[:first_split_index]
+        if action not in ["IMAGINE", "DESCRIBE", "UPSCALE",
+                          "VARIATION", "BLEND", "REROLL"
+                          ]:
+            yield "任务提交失败：未知的任务类型"
+            return
+
+        action_index = None
+        action_use_task_id = None
+        if action in ["VARIATION", "UPSCALE", "REROLL"]:
+            action_index = int(prompt[first_split_index + 2:first_split_index + 3])
+            action_use_task_id = prompt[first_split_index + 5:]
+
+        try:
+            res = None
+            if action == "IMAGINE":
+                data = {
+                    "prompt": prompt
+                }
+                if self.image_bytes is not None:
+                    data["base64"] = 'data:image/png;base64,' + self.image_bytes
+                res = self.request_mj("submit/imagine", "POST",
+                                      json.dumps(data))
+            elif action == "DESCRIBE":
+                res = self.request_mj("submit/describe", "POST", json.dumps(
+                    {"base64": 'data:image/png;base64,' + self.image_bytes}))
+            elif action == "BLEND":
+                res = self.request_mj("submit/blend", "POST", json.dumps(
+                    {"base64Array": [self.image_bytes, self.image_bytes]}))
+            elif action in ["UPSCALE", "VARIATION", "REROLL"]:
+                res = self.request_mj(
+                    "submit/change", "POST",
+                    json.dumps({"action": action, "index": action_index, "taskId": action_use_task_id}))
+            res_json = res.json()
+            if not (200 <= res.status_code < 300) or (res_json['code'] not in [1, 22]):
+                yield "任务提交失败：" + res_json.get('error', res_json.get('description', '未知错误'))
+            else:
+                task_id = res_json['result']
+                prefix_content = f"**画面描述:** {prompt}\n**任务ID:** {task_id}\n"
+                content = f"[{(datetime.now()).strftime('%Y-%m-%d %H:%M:%S')}] - 任务提交成功：" + \
+                    res_json.get('description') or '请稍等片刻'
+                yield content
+
+                fetch_data = Midjourney_Client.FetchDataPack(
+                    action=action,
+                    prefix_content=prefix_content,
+                    task_id=task_id,
+                )
+                while not fetch_data.finished:
+                    yield self.fetch_status(fetch_data)
+        except Exception as e:
+            logging.error('submit failed', e)
+            yield "任务提交错误：" + str(e.args[0]) if e.args else '未知错误'
+
+    def get_help(self):
+        return """```
+【绘图帮助】
+所有命令都需要以 /mj 开头，如：/mj a dog
+IMAGINE - 绘图，可以省略该命令，后面跟上绘图内容
+    /mj a dog
+    /mj IMAGINE::a cat
+DESCRIBE - 描述图片，需要在右下角上传需要描述的图片内容
+    /mj DESCRIBE::
+UPSCALE - 确认后放大图片，第一个数值为需要放大的图片（1~4），第二参数为任务ID
+    /mj UPSCALE::1::123456789
+    请使用SD进行UPSCALE
+VARIATION - 图片变体，第一个数值为需要放大的图片（1~4），第二参数为任务ID
+    /mj VARIATION::1::123456789
+    
+【绘图参数】
+所有命令默认会带上参数--v 5.2
+其他参数参照 https://docs.midjourney.com/docs/parameter-list
+长宽比 --aspect/--ar
+    --ar 1:2
+    --ar 16:9
+负面tag --no
+    --no plants
+    --no hands
+随机种子 --seed
+    --seed 1
+生成动漫风格（NijiJourney） --niji
+    --niji
+```
+"""

--- a/modules/models/models.py
+++ b/modules/models/models.py
@@ -621,6 +621,10 @@ def get_model(
         elif model_type == ModelType.LangchainChat:
             from .azure import Azure_OpenAI_Client
             model = Azure_OpenAI_Client(model_name, user_name=user_name)
+        elif model_type == ModelType.Midjourney:
+            from .midjourney import Midjourney_Client
+            mj_proxy_api_secret = os.getenv("MIDJOURNEY_PROXY_API_SECRET")
+            model = Midjourney_Client(model_name, mj_proxy_api_secret, user_name=user_name)
         elif model_type == ModelType.Unknown:
             raise ValueError(f"未知模型: {model_name}")
         logging.info(msg)

--- a/modules/presets.py
+++ b/modules/presets.py
@@ -69,6 +69,7 @@ ONLINE_MODELS = [
     "yuanai-1.0-rhythm_poems",
     "minimax-abab4-chat",
     "minimax-abab5-chat",
+    "midjourney"
 ]
 
 LOCAL_MODELS = [


### PR DESCRIPTION
<!--
这是一个拉取请求模板。本文段处于注释中，请您先查看本注释，在您提交时该段文字将不会显示。

1. 在提交拉取请求前，您最好已经查看过 [https://github.com/GaiZhenbiao/ChuanhuChatGPT/wiki/贡献指南] 了解了我们的大致要求；
2. 如果您的这一个pr包含多个不同的功能添加或问题修复，请务必将您的提交拆分为多个不同的原子化的commit，甚至您可以在不同的分支中提交多个pull request；
3. 不过，就算您的提交完全不合规范也没有关系，您可以直接提交，我们会进行审查。总之我们欢迎您做出贡献！

另外，我们将使用 Copilot4PR 自动补充撰写您的 pull request，请暂时不要删改 Copilot 撰写的内容。
-->

## 作者自述
### 描述
加入调用 https://github.com/novicezk/midjourney-proxy 来进行 MJ 图片生成/放大/变体。

使用效果：
![WechatIMG210](https://github.com/GaiZhenbiao/ChuanhuChatGPT/assets/4402804/130d417b-59c0-4c7a-bd6a-195cceab9759)

![2023-08-25 16-17-46_1](https://github.com/GaiZhenbiao/ChuanhuChatGPT/assets/4402804/eac6c3ab-5f34-4711-9997-23f549f083bf)


使用说明（及未配置后端服务地址时的报错）：
![WechatIMG209](https://github.com/GaiZhenbiao/ChuanhuChatGPT/assets/4402804/13d40b81-1047-40dd-9db4-844f132b9a1b)


### 相关问题
resolves #804 

### 补充信息
需要部署自己的 proxy 后端

<!-- 写明开发进度的例子： WIP EXAMPLE:

#### 开发进度
- [x] 已经做好的事情1
- [ ] 还要干的事情1
- [ ] 还要干的事情2

-->


<!-- ############ Copilot for pull request ############
     不要删除下面的内容！ DO NOT DELETE THE CONTENT BELOW! 
-->
## Copilot4PR
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at cc5c4b7</samp>

### Summary
🎨🚀🤖

<!--
1.  🎨 - This emoji represents the creative and artistic aspect of the MidJourney API, which allows users to generate and manipulate images based on text prompts. It also suggests the visual nature of the service and the possibility of creating colorful and diverse outputs.
2.  🚀 - This emoji represents the speed and efficiency of the MidJourney API, which uses a proxy server to handle requests and a Discord proxy to host images. It also suggests the innovation and advancement of the service and the potential for exploring new domains and scenarios.
3.  🤖 - This emoji represents the chatbot and AI aspect of the MidJourney API, which uses a neural network to process natural language and generate images. It also suggests the intelligence and interactivity of the service and the ability to converse and respond to users.
-->
This pull request adds support for the MidJourney API as a new chatbot model type for the ChuanhuChatGPT application. The MidJourney API is a service that generates and manipulates images based on text prompts. The pull request modifies the `base_model.py`, `config_example.json`, `config.py`, `models.py`, and `presets.py` files to enable the integration of the MidJourney API. It also adds a new module `midjourney.py` that defines a class for interacting with the MidJourney API.

> _We're sailing on the MidJourney, aye, aye, aye_
> _We're making images from words, aye, aye, aye_
> _We've got the proxy and the key, aye, aye, aye_
> _And a new `ModelType` for thee, aye, aye, aye_

### Walkthrough
*  Add support for MidJourney API, a service for image generation and manipulation based on text prompts ([link](https://github.com/GaiZhenbiao/ChuanhuChatGPT/pull/871/files?diff=unified&w=0#diff-14bcebbd2e61e96a87dd9c50755465566354a360b1085cd2ff7ddce3c4f1a1fdL10-R15), [link](https://github.com/GaiZhenbiao/ChuanhuChatGPT/pull/871/files?diff=unified&w=0#diff-b4ba4a3f84ff5c85c144b2b9c28c5046d1c692e91e8231e55931413f7f21f666R117-R125), [link](https://github.com/GaiZhenbiao/ChuanhuChatGPT/pull/871/files?diff=unified&w=0#diff-3ca0698dd4eab37da223f4972bcf159dcc951ce059737efc0663d44a1a214b06R144), [link](https://github.com/GaiZhenbiao/ChuanhuChatGPT/pull/871/files?diff=unified&w=0#diff-3ca0698dd4eab37da223f4972bcf159dcc951ce059737efc0663d44a1a214b06R170-R171), [link](https://github.com/GaiZhenbiao/ChuanhuChatGPT/pull/871/files?diff=unified&w=0#diff-92210a647774fbd5969a70edf4ce367d83ac66143e92d085091b7aae574fd00eR1-R385), [link](https://github.com/GaiZhenbiao/ChuanhuChatGPT/pull/871/files?diff=unified&w=0#diff-d1891fbe5981bc67a31d0b1aa8819ad6c4f88cd13a52eda5c74c318cb50889feR624-R627), [link](https://github.com/GaiZhenbiao/ChuanhuChatGPT/pull/871/files?diff=unified&w=0#diff-2dd7551ecfb886cb4c1d16aeaf528f71e7a90a5f317da67152b9f5e190ddfce6R72))
  - Add new configuration options for MidJourney API in `config_example.json` ([link](https://github.com/GaiZhenbiao/ChuanhuChatGPT/pull/871/files?diff=unified&w=0#diff-14bcebbd2e61e96a87dd9c50755465566354a360b1085cd2ff7ddce3c4f1a1fdL10-R15))
  - Set environment variables based on MidJourney configuration in `modules/config.py` ([link](https://github.com/GaiZhenbiao/ChuanhuChatGPT/pull/871/files?diff=unified&w=0#diff-b4ba4a3f84ff5c85c144b2b9c28c5046d1c692e91e8231e55931413f7f21f666R117-R125))
  - Add new enum value for MidJourney model type in `modules/models/base_model.py` ([link](https://github.com/GaiZhenbiao/ChuanhuChatGPT/pull/871/files?diff=unified&w=0#diff-3ca0698dd4eab37da223f4972bcf159dcc951ce059737efc0663d44a1a214b06R144))
  - Add new condition for determining MidJourney model type based on model name in `modules/models/base_model.py` ([link](https://github.com/GaiZhenbiao/ChuanhuChatGPT/pull/871/files?diff=unified&w=0#diff-3ca0698dd4eab37da223f4972bcf159dcc951ce059737efc0663d44a1a214b06R170-R171))
  - Add new module for MidJourney API in `modules/models/midjourney.py`, which defines a class that inherits from XMChat and implements the methods for interacting with the API ([link](https://github.com/GaiZhenbiao/ChuanhuChatGPT/pull/871/files?diff=unified&w=0#diff-92210a647774fbd5969a70edf4ce367d83ac66143e92d085091b7aae574fd00eR1-R385))
  - Add new branch for creating and returning a MidJourney_Client instance based on model type and name in `modules/models/models.py` ([link](https://github.com/GaiZhenbiao/ChuanhuChatGPT/pull/871/files?diff=unified&w=0#diff-d1891fbe5981bc67a31d0b1aa8819ad6c4f88cd13a52eda5c74c318cb50889feR624-R627))
  - Add new entry for MidJourney model in the list of available online models in `modules/presets.py` ([link](https://github.com/GaiZhenbiao/ChuanhuChatGPT/pull/871/files?diff=unified&w=0#diff-2dd7551ecfb886cb4c1d16aeaf528f71e7a90a5f317da67152b9f5e190ddfce6R72))

