### PR TITLE
增加对Anthropic的Claude大模型的支持

### DIFF
--- a/config_example.json
+++ b/config_example.json
@@ -14,6 +14,7 @@
     "spark_appid": "", // 你的 讯飞星火大模型 API AppID，用于讯飞星火大模型对话模型
     "spark_api_key": "", // 你的 讯飞星火大模型 API Key，用于讯飞星火大模型对话模型
     "spark_api_secret": "", // 你的 讯飞星火大模型 API Secret，用于讯飞星火大模型对话模型
+    "claude_api_secret":"",// 你的 Claude API Secret，用于 Claude 对话模型
 
 
     //== Azure ==

--- a/modules/config.py
+++ b/modules/config.py
@@ -128,6 +128,9 @@ os.environ["SPARK_APPID"] = spark_appid
 spark_api_secret = config.get("spark_api_secret", "")
 os.environ["SPARK_API_SECRET"] = spark_api_secret
 
+claude_api_secret = config.get("claude_api_secret", "")
+os.environ["CLAUDE_API_SECRET"] = claude_api_secret
+
 load_config_to_environ(["openai_api_type", "azure_openai_api_key", "azure_openai_api_base_url",
                        "azure_openai_api_version", "azure_deployment_name", "azure_embedding_deployment_name", "azure_embedding_model_name"])
 

--- a/modules/models/Claude.py
+++ b/modules/models/Claude.py
@@ -1,0 +1,55 @@
+
+from anthropic import Anthropic, HUMAN_PROMPT, AI_PROMPT
+from ..presets import *
+from ..utils import *
+
+from .base_model import BaseLLMModel
+
+
+class Claude_Client(BaseLLMModel):
+    def __init__(self, model_name, api_secret) -> None:
+        super().__init__(model_name=model_name)
+        self.api_secret = api_secret
+        if None in [self.api_secret]:
+            raise Exception("请在配置文件或者环境变量中设置Claude的API Secret")
+        self.claude_client = Anthropic(api_key=self.api_secret)
+
+
+    def get_answer_stream_iter(self):
+        system_prompt = self.system_prompt
+        history = self.history
+        if system_prompt is not None:
+            history = [construct_system(system_prompt), *history]
+
+        completion = self.claude_client.completions.create(
+            model=self.model_name,
+            max_tokens_to_sample=300,
+            prompt=f"{HUMAN_PROMPT}{history}{AI_PROMPT}",
+            stream=True,
+        )
+        if completion is not None:
+            partial_text = ""
+            for chunk in completion:
+                partial_text += chunk.completion
+                yield partial_text
+        else:
+            yield STANDARD_ERROR_MSG + GENERAL_ERROR_MSG
+
+
+    def get_answer_at_once(self):
+        system_prompt = self.system_prompt
+        history = self.history
+        if system_prompt is not None:
+            history = [construct_system(system_prompt), *history]
+
+        completion = self.claude_client.completions.create(
+            model=self.model_name,
+            max_tokens_to_sample=300,
+            prompt=f"{HUMAN_PROMPT}{history}{AI_PROMPT}",
+        )
+        if completion is not None:
+            return completion.completion, len(completion.completion)
+        else:
+            return "获取资源错误", 0
+
+

--- a/modules/models/base_model.py
+++ b/modules/models/base_model.py
@@ -145,6 +145,7 @@ class ModelType(Enum):
     Midjourney = 11
     Spark = 12
     OpenAIInstruct = 13
+    Claude = 14
 
     @classmethod
     def get_type(cls, model_name: str):
@@ -179,6 +180,8 @@ class ModelType(Enum):
             model_type = ModelType.LangchainChat
         elif "星火大模型" in model_name_lower:
             model_type = ModelType.Spark
+        elif "claude" in model_name_lower:
+            model_type = ModelType.Claude        
         else:
             model_type = ModelType.LLaMA
         return model_type

--- a/modules/models/models.py
+++ b/modules/models/models.py
@@ -116,6 +116,9 @@ def get_model(
             from .spark import Spark_Client
             model = Spark_Client(model_name, os.getenv("SPARK_APPID"), os.getenv(
                 "SPARK_API_KEY"), os.getenv("SPARK_API_SECRET"), user_name=user_name)
+         elif model_type == ModelType.Claude:
+            from .Claude import Claude_Client
+            model = Claude_Client(model_name="claude-2", api_secret=os.getenv("CLAUDE_API_SECRET"))
         elif model_type == ModelType.Unknown:
             raise ValueError(f"未知模型: {model_name}")
         logging.info(msg)

--- a/modules/presets.py
+++ b/modules/presets.py
@@ -74,7 +74,8 @@ ONLINE_MODELS = [
     "minimax-abab5-chat",
     "midjourney",
     "讯飞星火大模型V2.0",
-    "讯飞星火大模型V1.5"
+    "讯飞星火大模型V1.5",
+    "Claude"
 ]
 
 LOCAL_MODELS = [
@@ -125,7 +126,8 @@ MODEL_TOKEN_LIMIT = {
     "gpt-4-0613": 8192,
     "gpt-4-32k": 32768,
     "gpt-4-32k-0314": 32768,
-    "gpt-4-32k-0613": 32768
+    "gpt-4-32k-0613": 32768,
+    "Claude": 4096
 }
 
 TOKEN_OFFSET = 1000 # 模型的token上限减去这个值，得到软上限。到达软上限之后，自动尝试减少token占用。

--- a/requirements.txt
+++ b/requirements.txt
@@ -30,3 +30,5 @@ python-docx
 websocket_client
 pydantic==1.10.8
 google-search-results
+anthropic==0.3.11
+


### PR DESCRIPTION
<!--
这是一个拉取请求模板。本文段处于注释中，请您先查看本注释，在您提交时该段文字将不会显示。

1. 在提交拉取请求前，您最好已经查看过 [https://github.com/GaiZhenbiao/ChuanhuChatGPT/wiki/贡献指南] 了解了我们的大致要求；
2. 如果您的这一个pr包含多个不同的功能添加或问题修复，请务必将您的提交拆分为多个不同的原子化的commit，甚至您可以在不同的分支中提交多个pull request；
3. 不过，就算您的提交完全不合规范也没有关系，您可以直接提交，我们会进行审查。总之我们欢迎您做出贡献！

另外，我们将使用 Copilot4PR 自动补充撰写您的 pull request，请暂时不要删改 Copilot 撰写的内容。
-->


## 刘旭东
### 
这个版本增加了对与Anthropic的Claude模型的支持，可以使用Calude-2大模型进行问答
截图如下：
![FireShot Capture 003 - 川虎Chat 🚀 - 127 0 0 1](https://github.com/GaiZhenbiao/ChuanhuChatGPT/assets/1211835/a4bcd6b2-2999-4ebc-aad7-2acae9ed1ffd)
![FireShot Capture 001 - 川虎Chat 🚀 - 127 0 0 1](https://github.com/GaiZhenbiao/ChuanhuChatGPT/assets/1211835/73a0743f-9b7c-46b9-ab0f-8271ce4c2c02)
### 相关问题
[功能请求]: 能否加入claude #851

### 补充信息


<!-- 写明开发进度的例子： WIP EXAMPLE:

#### 开发进度
- [x] 已经做好的事情1
- [ ] 还要干的事情1
- [ ] 还要干的事情2

-->


<!-- ############ Copilot for pull request ############
     不要删除下面的内容！ DO NOT DELETE THE CONTENT BELOW! 
-->
## Copilot4PR
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 69ea923</samp>

### Summary
🔐🗣️🆕

<!--
1.  🔐 - This emoji represents the addition of the Claude API Secret configuration option, which is a security-related feature that requires a valid key to access the Claude model.
2.  🗣️ - This emoji represents the creation of the Claude client module, which is the main component for interacting with the Claude dialogue model and generating answers using natural language.
3.  🆕 - This emoji represents the support for the Claude model type in the ModelType class and the presets module, which are the parts of the code that handle model selection and configuration.
-->
This pull request adds support for the Claude model, a new online chatbot model from Anthropic, to the ChuanhuChatGPT project. It modifies the `ModelType` class, the `presets` module, and the `get_model` function to recognize and handle the Claude model. It also adds a new module `Claude.py` for the Claude client, and a new configuration option for the Claude API Secret.

> _To chat with Claude, a new model online_
> _We need a secret key to make it shine_
> _We read it from config or env_
> _And pass it to the `ClaudeClient` then_
> _We also update presets and `ModelType`_

### Walkthrough
*  Add support for Claude dialogue model from Anthropic ([link](https://github.com/GaiZhenbiao/ChuanhuChatGPT/pull/919/files?diff=unified&w=0#diff-14bcebbd2e61e96a87dd9c50755465566354a360b1085cd2ff7ddce3c4f1a1fdR17), [link](https://github.com/GaiZhenbiao/ChuanhuChatGPT/pull/919/files?diff=unified&w=0#diff-b4ba4a3f84ff5c85c144b2b9c28c5046d1c692e91e8231e55931413f7f21f666R131-R133), [link](https://github.com/GaiZhenbiao/ChuanhuChatGPT/pull/919/files?diff=unified&w=0#diff-3ca0698dd4eab37da223f4972bcf159dcc951ce059737efc0663d44a1a214b06R148), [link](https://github.com/GaiZhenbiao/ChuanhuChatGPT/pull/919/files?diff=unified&w=0#diff-3ca0698dd4eab37da223f4972bcf159dcc951ce059737efc0663d44a1a214b06R183-R184), [link](https://github.com/GaiZhenbiao/ChuanhuChatGPT/pull/919/files?diff=unified&w=0#diff-43813aecf7a7fb4eb086c75729094f44cad793d8bf46c07b445b073487880117R1-R55), [link](https://github.com/GaiZhenbiao/ChuanhuChatGPT/pull/919/files?diff=unified&w=0#diff-d1891fbe5981bc67a31d0b1aa8819ad6c4f88cd13a52eda5c74c318cb50889feR119-R121), [link](https://github.com/GaiZhenbiao/ChuanhuChatGPT/pull/919/files?diff=unified&w=0#diff-2dd7551ecfb886cb4c1d16aeaf528f71e7a90a5f317da67152b9f5e190ddfce6L77-R78), [link](https://github.com/GaiZhenbiao/ChuanhuChatGPT/pull/919/files?diff=unified&w=0#diff-2dd7551ecfb886cb4c1d16aeaf528f71e7a90a5f317da67152b9f5e190ddfce6L128-R130))
  - Read Claude API Secret from `config_example.json` or environment variable and set it as environment variable for Claude client module ([link](https://github.com/GaiZhenbiao/ChuanhuChatGPT/pull/919/files?diff=unified&w=0#diff-14bcebbd2e61e96a87dd9c50755465566354a360b1085cd2ff7ddce3c4f1a1fdR17), [link](https://github.com/GaiZhenbiao/ChuanhuChatGPT/pull/919/files?diff=unified&w=0#diff-b4ba4a3f84ff5c85c144b2b9c28c5046d1c692e91e8231e55931413f7f21f666R131-R133))
  - Add Claude model type to ModelType enum class in `base_model.py` and check model name for "claude" in get_type method ([link](https://github.com/GaiZhenbiao/ChuanhuChatGPT/pull/919/files?diff=unified&w=0#diff-3ca0698dd4eab37da223f4972bcf159dcc951ce059737efc0663d44a1a214b06R148), [link](https://github.com/GaiZhenbiao/ChuanhuChatGPT/pull/919/files?diff=unified&w=0#diff-3ca0698dd4eab37da223f4972bcf159dcc951ce059737efc0663d44a1a214b06R183-R184))
  - Create Claude client module in `Claude.py` that inherits from base language model class and implements methods for generating answers using Claude API and Anthropic library ([link](https://github.com/GaiZhenbiao/ChuanhuChatGPT/pull/919/files?diff=unified&w=0#diff-43813aecf7a7fb4eb086c75729094f44cad793d8bf46c07b445b073487880117R1-R55))
  - Add branch to get_model function in `models.py` that creates and returns Claude client instance if model type is Claude ([link](https://github.com/GaiZhenbiao/ChuanhuChatGPT/pull/919/files?diff=unified&w=0#diff-d1891fbe5981bc67a31d0b1aa8819ad6c4f88cd13a52eda5c74c318cb50889feR119-R121))
  - Add Claude model name to online models list and model token limits dictionary in `presets.py` ([link](https://github.com/GaiZhenbiao/ChuanhuChatGPT/pull/919/files?diff=unified&w=0#diff-2dd7551ecfb886cb4c1d16aeaf528f71e7a90a5f317da67152b9f5e190ddfce6L77-R78), [link](https://github.com/GaiZhenbiao/ChuanhuChatGPT/pull/919/files?diff=unified&w=0#diff-2dd7551ecfb886cb4c1d16aeaf528f71e7a90a5f317da67152b9f5e190ddfce6L128-R130))

