### PR TITLE
buxfix: set autocomplete attribute to api-key input

### DIFF
--- a/ChuanhuChatbot.py
+++ b/ChuanhuChatbot.py
@@ -205,6 +205,7 @@ with gr.Blocks(theme=small_and_beautiful_theme) as demo:
                                 type="password",
                                 visible=not HIDE_MY_KEY,
                                 label="API-Key",
+                                elem_id="api-key"
                             )
                             if multi_api_key:
                                 usageTxt = gr.Markdown(i18n(

--- a/web_assets/javascript/ChuanhuChat.js
+++ b/web_assets/javascript/ChuanhuChat.js
@@ -109,6 +109,7 @@ function initialize() {
     setPopupBoxPosition();
     setSlider();
     setCheckboxes();
+    setAPIKey();
     checkModel();
 
     settingBox.classList.add('hideBox');
@@ -334,6 +335,11 @@ function setChatbotHeight() {
 function setChatbotScroll() {
     var scrollHeight = chatbotWrap.scrollHeight;
     chatbotWrap.scrollTo(0,scrollHeight)
+}
+
+function setAPIKey() {
+    const apiKey = gradioApp().querySelector("#api-key input");
+    apiKey.setAttribute("autocomplete", "new-password");
 }
 
 function clearChatbot(a, b) {

--- a/web_assets/javascript/ChuanhuChat.js
+++ b/web_assets/javascript/ChuanhuChat.js
@@ -109,7 +109,7 @@ function initialize() {
     setPopupBoxPosition();
     setSlider();
     setCheckboxes();
-    setAPIKey();
+    setAutocomplete();
     checkModel();
 
     settingBox.classList.add('hideBox');
@@ -337,9 +337,10 @@ function setChatbotScroll() {
     chatbotWrap.scrollTo(0,scrollHeight)
 }
 
-function setAPIKey() {
-    const apiKey = gradioApp().querySelector("#api-key input");
-    apiKey.setAttribute("autocomplete", "new-password");
+function setAutocomplete() {
+    // 避免API Key被当成密码导致的模型下拉框被当成用户名而引发的浏览器自动填充行为
+    const apiKeyInput = gradioApp().querySelector("#api-key input");
+    apiKeyInput.setAttribute("autocomplete", "new-password");
 }
 
 function clearChatbot(a, b) {


### PR DESCRIPTION
<!--
这是一个拉取请求模板。本文段处于注释中，请您先查看本注释，在您提交时该段文字将不会显示。
This is a pull request template. This paragraph is in the comments, please review this note first, the text will not be displayed when you submit it.

1. 在提交拉取请求前，您最好已经查看过 [https://github.com/GaiZhenbiao/ChuanhuChatGPT/wiki/贡献指南] 了解了我们的大致要求；
2. 如果您的这一个pr包含多个不同的功能添加或问题修复，请务必将您的提交拆分为多个不同的原子化的commit，甚至您可以在不同的分支中提交多个pull request；
3. 不过，就算您的提交完全不合规范也没有关系，您可以直接提交，我们会进行审查。总之我们欢迎您做出贡献！

1. Before submitting a pull request, it is recommended that you have already reviewed [https://github.com/GaiZhenbiao/ChuanhuChatGPT/wiki/贡献指南] to understand our general requirements.
2. If your pull request includes multiple different feature additions or bug fixes, please make sure to split your submission into multiple atomic commits. You can even submit multiple pull requests in different branches.
3. However, even if your submission does not fully comply with the guidelines, feel free to submit it directly; we will review it. In any case, we welcome your contributions!
-->

## 作者自述
### 描述

使用 new-password 作为 autocompletion 属性的值，以避免 chrome 显示密码自动提示框。

https://developer.mozilla.org/en-US/docs/Web/Security/Securing_your_site/Turning_off_form_autocompletion#preventing_autofilling_with_autocompletenew-password

before:

![image](https://github.com/GaiZhenbiao/ChuanhuChatGPT/assets/6214067/957eb73a-4915-4b4d-83f4-081bab8cf6d3)

after:

![image](https://github.com/GaiZhenbiao/ChuanhuChatGPT/assets/6214067/f0ed4ccf-3b6d-48e6-9ff2-473cef9b5172)


### 相关问题

https://github.com/GaiZhenbiao/ChuanhuChatGPT/issues/1020

<!-- ############ Copilot for pull request ############
     不要删除下面的内容！ DO NOT DELETE THE CONTENT BELOW! 

## Copilot4PR [decrepated on 2023-12-15]
copilot:all
-->
