### PR TITLE
feat:替代并实现gradio logout route并添加退出按钮

### DIFF
--- a/ChuanhuChatbot.py
+++ b/ChuanhuChatbot.py
@@ -394,7 +394,7 @@ with gr.Blocks(theme=small_and_beautiful_theme) as demo:
                             "单轮对话"), value=False, elem_classes="switch-checkbox", elem_id="gr-single-session-cb", visible=False)
                         # checkUpdateBtn = gr.Button(i18n("🔄 检查更新..."), visible=check_update)
                         logout_btn = gr.Button(
-                            i18n("退出用户"), variant="primary", interactive=authflag)
+                            i18n("退出用户"), variant="primary", visible=authflag)
 
                     with gr.Tab(i18n("网络")):
                         gr.Markdown(

--- a/ChuanhuChatbot.py
+++ b/ChuanhuChatbot.py
@@ -16,7 +16,9 @@ from modules.config import *
 from modules import config
 import gradio as gr
 import colorama
+from modules.gradio_patch import reg_patch
 
+reg_patch()
 
 logging.getLogger("httpx").setLevel(logging.WARNING)
 
@@ -33,6 +35,8 @@ def create_new_model():
 
 with gr.Blocks(theme=small_and_beautiful_theme) as demo:
     user_name = gr.Textbox("", visible=False)
+    # 激活/logout路由
+    logout_hidden_btn = gr.LogoutButton(visible=False)
     promptTemplates = gr.State(load_template(get_template_names()[0], mode=2))
     user_question = gr.State("")
     assert type(my_api_key) == str
@@ -389,6 +393,8 @@ with gr.Blocks(theme=small_and_beautiful_theme) as demo:
                         single_turn_checkbox = gr.Checkbox(label=i18n(
                             "单轮对话"), value=False, elem_classes="switch-checkbox", elem_id="gr-single-session-cb", visible=False)
                         # checkUpdateBtn = gr.Button(i18n("🔄 检查更新..."), visible=check_update)
+                        logout_btn = gr.Button(
+                            i18n("退出用户"), variant="primary", interactive=authflag)
 
                     with gr.Tab(i18n("网络")):
                         gr.Markdown(
@@ -790,7 +796,12 @@ with gr.Blocks(theme=small_and_beautiful_theme) as demo:
         outputs=[saveFileName, systemPromptTxt, chatbot, single_turn_checkbox, temperature_slider, top_p_slider, n_choices_slider, stop_sequence_txt, max_context_length_slider, max_generation_slider, presence_penalty_slider, frequency_penalty_slider, logit_bias_txt, user_identifier_txt],
         _js='(a,b)=>{return bgSelectHistory(a,b);}'
     )
-
+    logout_btn.click(
+            fn=None,
+            inputs=[],
+            outputs=[],
+            _js='self.location="/logout"'
+        )
 # 默认开启本地服务器，默认可以直接从IP访问，默认不创建公开分享链接
 demo.title = i18n("川虎Chat 🚀")
 

--- a/modules/gradio_patch.py
+++ b/modules/gradio_patch.py
@@ -1,0 +1,114 @@
+import logging
+import os
+
+import fastapi
+import gradio
+from fastapi.responses import RedirectResponse
+from gradio.oauth import MOCKED_OAUTH_TOKEN
+
+from modules.presets import i18n
+
+OAUTH_CLIENT_ID = os.environ.get("OAUTH_CLIENT_ID")
+OAUTH_CLIENT_SECRET = os.environ.get("OAUTH_CLIENT_SECRET")
+OAUTH_SCOPES = os.environ.get("OAUTH_SCOPES")
+OPENID_PROVIDER_URL = os.environ.get("OPENID_PROVIDER_URL")
+def _add_oauth_routes(app: fastapi.FastAPI) -> None:
+    """Add OAuth routes to the FastAPI app (login, callback handler and logout)."""
+    try:
+        from authlib.integrations.starlette_client import OAuth
+    except ImportError as e:
+        raise ImportError(
+            "Cannot initialize OAuth to due a missing library. Please run `pip install gradio[oauth]` or add "
+            "`gradio[oauth]` to your requirements.txt file in order to install the required dependencies."
+        ) from e
+
+    # Check environment variables
+    msg = (
+        "OAuth is required but {} environment variable is not set. Make sure you've enabled OAuth in your Space by"
+        " setting `hf_oauth: true` in the Space metadata."
+    )
+    if OAUTH_CLIENT_ID is None:
+        raise ValueError(msg.format("OAUTH_CLIENT_ID"))
+    if OAUTH_CLIENT_SECRET is None:
+        raise ValueError(msg.format("OAUTH_CLIENT_SECRET"))
+    if OAUTH_SCOPES is None:
+        raise ValueError(msg.format("OAUTH_SCOPES"))
+    if OPENID_PROVIDER_URL is None:
+        raise ValueError(msg.format("OPENID_PROVIDER_URL"))
+
+    # Register OAuth server
+    oauth = OAuth()
+    oauth.register(
+        name="huggingface",
+        client_id=OAUTH_CLIENT_ID,
+        client_secret=OAUTH_CLIENT_SECRET,
+        client_kwargs={"scope": OAUTH_SCOPES},
+        server_metadata_url=OPENID_PROVIDER_URL + "/.well-known/openid-configuration",
+    )
+
+    # Define OAuth routes
+    @app.get("/login/huggingface")
+    async def oauth_login(request: fastapi.Request):
+        """Endpoint that redirects to HF OAuth page."""
+        redirect_uri = str(request.url_for("oauth_redirect_callback"))
+        if ".hf.space" in redirect_uri:
+            # In Space, FastAPI redirect as http but we want https
+            redirect_uri = redirect_uri.replace("http://", "https://")
+        return await oauth.huggingface.authorize_redirect(request, redirect_uri)
+
+    @app.get("/login/callback")
+    async def oauth_redirect_callback(request: fastapi.Request) -> RedirectResponse:
+        """Endpoint that handles the OAuth callback."""
+        token = await oauth.huggingface.authorize_access_token(request)
+        request.session["oauth_profile"] = token["userinfo"]
+        request.session["oauth_token"] = token
+        return RedirectResponse("/")
+
+    @app.get("/logout")
+    async def oauth_logout(request: fastapi.Request) -> RedirectResponse:
+        """Endpoint that logs out the user (e.g. delete cookie session)."""
+        request.session.pop("oauth_profile", None)
+        request.session.pop("oauth_token", None)
+        # 清除cookie并跳转到首页
+        response = RedirectResponse(url="/", status_code=302)
+        response.delete_cookie(key=f"access-token")
+        response.delete_cookie(key=f"access-token-unsecure")
+        return response
+
+
+def _add_mocked_oauth_routes(app: fastapi.FastAPI) -> None:
+    """Add fake oauth routes if Gradio is run locally and OAuth is enabled.
+
+    Clicking on a gr.LoginButton will have the same behavior as in a Space (i.e. gets redirected in a new tab) but
+    instead of authenticating with HF, a mocked user profile is added to the session.
+    """
+
+    # Define OAuth routes
+    @app.get("/login/huggingface")
+    async def oauth_login(request: fastapi.Request):
+        """Fake endpoint that redirects to HF OAuth page."""
+        return RedirectResponse("/login/callback")
+
+    @app.get("/login/callback")
+    async def oauth_redirect_callback(request: fastapi.Request) -> RedirectResponse:
+        """Endpoint that handles the OAuth callback."""
+        request.session["oauth_profile"] = MOCKED_OAUTH_TOKEN["userinfo"]
+        request.session["oauth_token"] = MOCKED_OAUTH_TOKEN
+        return RedirectResponse("/")
+
+    @app.get("/logout")
+    async def oauth_logout(request: fastapi.Request) -> RedirectResponse:
+        """Endpoint that logs out the user (e.g. delete cookie session)."""
+        request.session.pop("oauth_profile", None)
+        request.session.pop("oauth_token", None)
+        # 清除cookie并跳转到首页
+        response = RedirectResponse(url="/", status_code=302)
+        response.delete_cookie(key=f"access-token")
+        response.delete_cookie(key=f"access-token-unsecure")
+        return response
+
+
+def reg_patch():
+    gradio.oauth._add_mocked_oauth_routes = _add_mocked_oauth_routes
+    gradio.oauth._add_oauth_routes = _add_oauth_routes
+    logging.info(i18n("覆盖gradio.oauth /logout路由"))


### PR DESCRIPTION
<!--
这是一个拉取请求模板。本文段处于注释中，请您先查看本注释，在您提交时该段文字将不会显示。
This is a pull request template. This paragraph is in the comments, please review this note first, the text will not be displayed when you submit it.

1. 在提交拉取请求前，您最好已经查看过 [https://github.com/GaiZhenbiao/ChuanhuChatGPT/wiki/贡献指南] 了解了我们的大致要求；
2. 如果您的这一个pr包含多个不同的功能添加或问题修复，请务必将您的提交拆分为多个不同的原子化的commit，甚至您可以在不同的分支中提交多个pull request；
3. 不过，就算您的提交完全不合规范也没有关系，您可以直接提交，我们会进行审查。总之我们欢迎您做出贡献！

1. Before submitting a pull request, it is recommended that you have already reviewed [https://github.com/GaiZhenbiao/ChuanhuChatGPT/wiki/贡献指南] to understand our general requirements.
2. If your pull request includes multiple different feature additions or bug fixes, please make sure to split your submission into multiple atomic commits. You can even submit multiple pull requests in different branches.
3. However, even if your submission does not fully comply with the guidelines, feel free to submit it directly; we will review it. In any case, we welcome your contributions!
-->

## 作者自述
### 描述
gradio 3.43.2 对于logout处理并不正确，因此添加补丁实现新的logout route，添加退出时删除cookie功能，实现正常退出功能，在多用户场景、公共场景保护自己隐私和防止滥用有较高需求。
退出按钮添加到设置页面中。点击后跳转到自己实现的/logout非gradio的/logout，如果未来切换版本的话需要考虑更新patch。

![image](https://github.com/GaiZhenbiao/ChuanhuChatGPT/assets/1651804/18a6f2f9-6661-43fd-8dd4-ba5d077dd789)

### 相关问题
无

### 补充信息
本地部署情况测试通过，huggingface space部署情况未测试


<!-- ############ Copilot for pull request ############
     不要删除下面的内容！ DO NOT DELETE THE CONTENT BELOW! 

## Copilot4PR [decrepated on 2023-12-15]
copilot:all
-->
