### PR TITLE
Fix stop sequence initialization as empty string

### DIFF
--- a/modules/models/base_model.py
+++ b/modules/models/base_model.py
@@ -245,7 +245,7 @@ class BaseLLMModel:
         temperature=1.0,
         top_p=1.0,
         n_choices=1,
-        stop="",
+        stop=[],
         max_generation_token=None,
         presence_penalty=0,
         frequency_penalty=0,


### PR DESCRIPTION
<!--
这是一个拉取请求模板。本文段处于注释中，请您先查看本注释，在您提交时该段文字将不会显示。
This is a pull request template. This paragraph is in the comments, please review this note first, the text will not be displayed when you submit it.

1. 在提交拉取请求前，您最好已经查看过 [https://github.com/GaiZhenbiao/ChuanhuChatGPT/wiki/贡献指南] 了解了我们的大致要求；
2. 如果您的这一个pr包含多个不同的功能添加或问题修复，请务必将您的提交拆分为多个不同的原子化的commit，甚至您可以在不同的分支中提交多个pull request；
3. 不过，就算您的提交完全不合规范也没有关系，您可以直接提交，我们会进行审查。总之我们欢迎您做出贡献！

1. Before submitting a pull request, it is recommended that you have already reviewed [https://github.com/GaiZhenbiao/ChuanhuChatGPT/wiki/贡献指南] to understand our general requirements.
2. If your pull request includes multiple different feature additions or bug fixes, please make sure to split your submission into multiple atomic commits. You can even submit multiple pull requests in different branches.
3. However, even if your submission does not fully comply with the guidelines, feel free to submit it directly; we will review it. In any case, we welcome your contributions!
-->

## 作者自述
### 描述
修复 Bug：https://github.com/GaiZhenbiao/ChuanhuChatGPT/issues/1007

当模型初始化时，stop sequence 设置为空字符串，某些模型会在生成回复时直接停止回复，导致切换模型后失败。如果调用 set_stop_sequence 后可以 workaround。本质上是 stop sequence 的数据类型错了。

### 相关问题
[[Bug]: 每次切换模型后回复都为空 #1007](https://github.com/GaiZhenbiao/ChuanhuChatGPT/issues/1007)

### 补充信息
无


<!-- ############ Copilot for pull request ############
     不要删除下面的内容！ DO NOT DELETE THE CONTENT BELOW! 

## Copilot4PR [decrepated on 2023-12-15]
copilot:all
-->
