### PR TITLE
fix: incorrect argument structure passing to super().init() in Groq_Client.init()

### DIFF
--- a/modules/models/Groq.py
+++ b/modules/models/Groq.py
@@ -18,7 +18,13 @@ from .base_model import BaseLLMModel
 
 class Groq_Client(BaseLLMModel):
     def __init__(self, model_name, api_key, user_name="") -> None:
-        super().__init__(model_name=model_name, user=user_name, api_key=api_key)
+        super().__init__(
+            model_name=model_name, 
+            user=user_name, 
+            config={
+                "api_key": api_key
+            }
+        )
         self.client = Groq(
             api_key=os.environ.get("GROQ_API_KEY"),
             base_url=self.api_host,


### PR DESCRIPTION
When calling super().init() in Groq_Client.init(), based on the init() function definition in BaseLLMModel, the last argument should be `config={"api_key":api_key}`, instead of `api_key=api_key`

## 作者自述
### 描述
修正 models/Groq.py 文件里 Groq_Client 类 __init__ 函数中 super().__init__() 参数格式错误

### 相关问题
#1121 

### 补充信息
修改后与其它模型参数传递格式一致。


<!-- ############ Copilot for pull request ############
     不要删除下面的内容！ DO NOT DELETE THE CONTENT BELOW! 

## Copilot4PR [decrepated on 2023-12-15]
copilot:all
-->
