### PR TITLE
fix: 修复循环引用导致无法使用知识库的问题 , fix #1133

### DIFF
--- a/modules/utils.py
+++ b/modules/utils.py
@@ -31,6 +31,7 @@ from modules.config import retrieve_proxy, hide_history_when_not_logged_in
 
 if TYPE_CHECKING:
     from typing import TypedDict
+    from .models.base_model import BaseLLMModel
 
     class DataframeData(TypedDict):
         headers: List[str]
@@ -1429,7 +1430,6 @@ def reboot_chuanhu():
     os.execl(sys.executable, sys.executable, *sys.argv)
 
 
-from .models.base_model import BaseLLMModel
 def setPlaceholder(model_name: str | None = "", model: BaseLLMModel | None = None):
     from .webui import get_html
     logo_class, slogan_class, question_class = "", "", ""


### PR DESCRIPTION
### 描述

修复utils.py循环引用BaseLLMModel导致无法使用知识库。
将`from .models.base_model import BaseLLMModel`移至`if TYPE_CHECKING:`中

### 相关问题

#1133 