### PR TITLE
feat：修改讯飞大模型名称为“官网”对应名称；同时增加 Spark Pro-128K类型；

### DIFF
--- a/modules/models/base_model.py
+++ b/modules/models/base_model.py
@@ -209,7 +209,7 @@ class ModelType(Enum):
             model_type = ModelType.Midjourney
         elif "azure" in model_name_lower or "api" in model_name_lower:
             model_type = ModelType.LangchainChat
-        elif "星火大模型" in model_name_lower:
+        elif "讯飞星火" in model_name_lower:
             model_type = ModelType.Spark
         elif "claude" in model_name_lower:
             model_type = ModelType.Claude

--- a/modules/models/spark.py
+++ b/modules/models/spark.py
@@ -72,8 +72,8 @@ class Spark_Client(BaseLLMModel):
         self.api_secret = api_secret
         if None in [self.api_key, self.appid, self.api_secret]:
             raise Exception("请在配置文件或者环境变量中设置讯飞的API Key、APP ID和API Secret")
-        self.spark_url = f"wss://spark-api.xf-yun.com{self.placeholder['path']}"
-        self.domain = self.placeholder['domain']
+        self.spark_url = f"wss://spark-api.xf-yun.com{self.metadata['path']}"
+        self.domain = self.metadata['domain']
 
     # 收到websocket错误的处理
     def on_error(self, ws, error):

--- a/modules/models/spark.py
+++ b/modules/models/spark.py
@@ -72,21 +72,8 @@ class Spark_Client(BaseLLMModel):
         self.api_secret = api_secret
         if None in [self.api_key, self.appid, self.api_secret]:
             raise Exception("请在配置文件或者环境变量中设置讯飞的API Key、APP ID和API Secret")
-        if "2.0" in self.model_name:
-            self.spark_url = "wss://spark-api.xf-yun.com/v2.1/chat"
-            self.domain = "generalv2"
-        elif "3.0" in self.model_name:
-            self.spark_url = "wss://spark-api.xf-yun.com/v3.1/chat"
-            self.domain = "generalv3"
-        elif "3.5" in self.model_name:
-            self.spark_url = "wss://spark-api.xf-yun.com/v3.5/chat"
-            self.domain = "generalv3.5"
-        elif "4.0" in self.model_name:
-            self.spark_url = "wss://spark-api.xf-yun.com/v4.0/chat"
-            self.domain = "4.0Ultra"
-        else:
-            self.spark_url = "wss://spark-api.xf-yun.com/v1.1/chat"
-            self.domain = "general"
+        self.spark_url = f"wss://spark-api.xf-yun.com{self.placeholder['path']}"
+        self.domain = self.placeholder['domain']
 
     # 收到websocket错误的处理
     def on_error(self, ws, error):

--- a/modules/presets.py
+++ b/modules/presets.py
@@ -84,11 +84,19 @@ ONLINE_MODELS = [
     "yuanai-1.0-rhythm_poems",
     "minimax-abab5-chat",
     "midjourney",
+    # 兼容旧配置文件，待删除
     "讯飞星火大模型V4.0",
     "讯飞星火大模型V3.5",
     "讯飞星火大模型V3.0",
     "讯飞星火大模型V2.0",
     "讯飞星火大模型V1.5",
+    # 新的名称
+    "讯飞星火4.0 Ultra",
+    "讯飞星火Max",
+    "讯飞星火Pro 128K",
+    "讯飞星火Pro",
+    "讯飞星火V2.0",
+    "讯飞星火Lite",
     "ERNIE-Bot-turbo",
     "ERNIE-Bot",
     "ERNIE-Bot-4",
@@ -382,11 +390,87 @@ MODEL_METADATA = {
     "yuanai-1.0-rhythm_poems": {"model_name": "yuanai-1.0-rhythm_poems"},
     "minimax-abab5-chat": {"model_name": "minimax-abab5-chat"},
     "midjourney": {"model_name": "midjourney"},
-    "讯飞星火大模型V4.0": {"model_name": "讯飞星火大模型V4.0"},
-    "讯飞星火大模型V3.5": {"model_name": "讯飞星火大模型V3.5"},
-    "讯飞星火大模型V3.0": {"model_name": "讯飞星火大模型V3.0"},
-    "讯飞星火大模型V2.0": {"model_name": "讯飞星火大模型V2.0"},
-    "讯飞星火大模型V1.5": {"model_name": "讯飞星火大模型V1.5"},
+    # 兼容旧配置文件，待删除
+    "讯飞星火大模型V4.0": {
+        "model_name": "讯飞星火大模型V4.0",
+        "placeholder": {
+            "path": "/v4.0/chat",
+            "domain": "4.0Ultra"
+        }
+    },
+    "讯飞星火大模型V3.5": {
+        "model_name": "讯飞星火大模型V3.5",
+        "placeholder": {
+            "path": "/v3.5/chat",
+            "domain": "generalv3.5"
+        }
+    },
+    "讯飞星火大模型V3.0": {
+        "model_name": "讯飞星火大模型V3.0",
+        "placeholder": {
+            "path": "/v3.1/chat",
+            "domain": "generalv3"
+        }
+    },
+    "讯飞星火大模型V2.0": {
+        "model_name": "讯飞星火大模型V2.0",
+        "placeholder": {
+            "path": "/v2.1/chat",
+            "domain": "generalv2"
+        }
+    },
+    "讯飞星火大模型V1.5": {
+        "model_name": "讯飞星火大模型V1.5",
+        "placeholder": {
+            "path": "/v1.1/chat",
+            "domain": "general"
+        }
+    },
+    # 新的名称
+    "讯飞星火4.0 Ultra": {
+        "model_name": "讯飞星火4.0 Ultra",
+        "placeholder": {
+            "path": "/v4.0/chat",
+            "domain": "4.0Ultra"
+        }
+    },
+    "讯飞星火Max": {
+        "model_name": "讯飞星火Max",
+        "placeholder": {
+            "path": "/v3.5/chat",
+            "domain": "generalv3.5"
+        }
+    },
+
+    "讯飞星火Pro 128K": {
+        "model_name": "讯飞星火Pro 128K",
+        "token_limit": 128000,
+        "placeholder": {
+            "path": "/chat/pro-128k",
+            "domain": "pro-128k"
+        }
+    },
+    "讯飞星火Pro": {
+        "model_name": "讯飞星火Pro",
+        "placeholder": {
+            "path": "/v3.1/chat",
+            "domain": "generalv3"
+        }
+    },
+    "讯飞星火V2.0": {
+        "model_name": "讯飞星火V2.0",
+        "placeholder": {
+            "path": "/v2.1/chat",
+            "domain": "generalv2"
+        }
+    },
+    "讯飞星火Lite": {
+        "model_name": "讯飞星火Lite",
+        "placeholder": {
+            "path": "/v1.1/chat",
+            "domain": "general"
+        }
+    }
 }
 
 if os.environ.get('HIDE_LOCAL_MODELS', 'false') == 'true':

--- a/modules/presets.py
+++ b/modules/presets.py
@@ -393,35 +393,38 @@ MODEL_METADATA = {
     # 兼容旧配置文件，待删除
     "讯飞星火大模型V4.0": {
         "model_name": "讯飞星火大模型V4.0",
-        "placeholder": {
+        "token_limit": 8192,
+        "metadata": {
             "path": "/v4.0/chat",
             "domain": "4.0Ultra"
         }
     },
     "讯飞星火大模型V3.5": {
         "model_name": "讯飞星火大模型V3.5",
-        "placeholder": {
+        "token_limit": 8192,
+        "metadata": {
             "path": "/v3.5/chat",
             "domain": "generalv3.5"
         }
     },
     "讯飞星火大模型V3.0": {
         "model_name": "讯飞星火大模型V3.0",
-        "placeholder": {
+        "token_limit": 8192,
+        "metadata": {
             "path": "/v3.1/chat",
             "domain": "generalv3"
         }
     },
     "讯飞星火大模型V2.0": {
         "model_name": "讯飞星火大模型V2.0",
-        "placeholder": {
+        "metadata": {
             "path": "/v2.1/chat",
             "domain": "generalv2"
         }
     },
     "讯飞星火大模型V1.5": {
         "model_name": "讯飞星火大模型V1.5",
-        "placeholder": {
+        "metadata": {
             "path": "/v1.1/chat",
             "domain": "general"
         }
@@ -429,14 +432,16 @@ MODEL_METADATA = {
     # 新的名称
     "讯飞星火4.0 Ultra": {
         "model_name": "讯飞星火4.0 Ultra",
-        "placeholder": {
+        "token_limit": 8192,
+        "metadata": {
             "path": "/v4.0/chat",
             "domain": "4.0Ultra"
         }
     },
     "讯飞星火Max": {
         "model_name": "讯飞星火Max",
-        "placeholder": {
+        "token_limit": 8192,
+        "metadata": {
             "path": "/v3.5/chat",
             "domain": "generalv3.5"
         }
@@ -444,29 +449,30 @@ MODEL_METADATA = {
 
     "讯飞星火Pro 128K": {
         "model_name": "讯飞星火Pro 128K",
-        "token_limit": 128000,
-        "placeholder": {
+        "token_limit": 131072, # 128 * 1024
+        "metadata": {
             "path": "/chat/pro-128k",
             "domain": "pro-128k"
         }
     },
     "讯飞星火Pro": {
         "model_name": "讯飞星火Pro",
-        "placeholder": {
+        "token_limit": 8192,
+        "metadata": {
             "path": "/v3.1/chat",
             "domain": "generalv3"
         }
     },
     "讯飞星火V2.0": {
         "model_name": "讯飞星火V2.0",
-        "placeholder": {
+        "metadata": {
             "path": "/v2.1/chat",
             "domain": "generalv2"
         }
     },
     "讯飞星火Lite": {
         "model_name": "讯飞星火Lite",
-        "placeholder": {
+        "metadata": {
             "path": "/v1.1/chat",
             "domain": "general"
         }


### PR DESCRIPTION
<!--
这是一个拉取请求模板。本文段处于注释中，请您先查看本注释，在您提交时该段文字将不会显示。
This is a pull request template. This paragraph is in the comments, please review this note first, the text will not be displayed when you submit it.

1. 在提交拉取请求前，您最好已经查看过 [https://github.com/GaiZhenbiao/ChuanhuChatGPT/wiki/贡献指南] 了解了我们的大致要求；
2. 如果您的这一个pr包含多个不同的功能添加或问题修复，请务必将您的提交拆分为多个不同的原子化的commit，甚至您可以在不同的分支中提交多个pull request；
3. 不过，就算您的提交完全不合规范也没有关系，您可以直接提交，我们会进行审查。总之我们欢迎您做出贡献！

1. Before submitting a pull request, it is recommended that you have already reviewed [https://github.com/GaiZhenbiao/ChuanhuChatGPT/wiki/贡献指南] to understand our general requirements.
2. If your pull request includes multiple different feature additions or bug fixes, please make sure to split your submission into multiple atomic commits. You can even submit multiple pull requests in different branches.
3. However, even if your submission does not fully comply with the guidelines, feel free to submit it directly; we will review it. In any case, we welcome your contributions!
-->

## 作者自述
### 描述
现有项目中，讯飞大模型以版本号为名称，和官方文档不一致，使用过程中难免有些困惑，所以建议修改为“官网”对应名称，参考官方链接 [讯飞接口说明-请求地址](https://www.xfyun.cn/doc/spark/Web.html#_1-%E6%8E%A5%E5%8F%A3%E8%AF%B4%E6%98%8E)

v4.0 -> Spark4.0 Ultra
v3.5 -> Spark Max
v3.0 -> Spark Pro
。。。

同时新增 Spark Pro-128K模型

### 相关问题

#1136 

### 补充信息

1. 目前为了兼容旧的配置文件，还保留了旧的带版本的名称，可以看情况删除
2. 模型相关的配置，被我放到了 `placeholder` 字段，可以看情况做调整


<!-- ############ Copilot for pull request ############
     不要删除下面的内容！ DO NOT DELETE THE CONTENT BELOW! 

## Copilot4PR [decrepated on 2023-12-15]
copilot:all
-->
