### PR TITLE
feat: add Astraflow provider support

### DIFF
--- a/config_example.json
+++ b/config_example.json
@@ -22,6 +22,8 @@
     "ollama_host": "", // 你的 Ollama Host，用于 Ollama 对话模型
     "huggingface_auth_token": "", // 你的 Hugging Face API Token，用于访问有限制的模型
     "groq_api_key": "", // 你的 Groq API Key，用于 Groq 对话模型(https://console.groq.com/)
+    "astraflow_api_key": "", // 你的 Astraflow API Key，用于 Astraflow 对话模型（全球端点: https://astraflow.ucloud-global.com）
+    "astraflow_cn_api_key": "", // 你的 Astraflow API Key，用于 Astraflow 对话模型（中国端点: https://astraflow.ucloud.cn）
 
     //== Azure ==
     "openai_api_type": "openai", // 可选项：azure, openai

--- a/modules/config.py
+++ b/modules/config.py
@@ -180,6 +180,14 @@ os.environ["OLLAMA_HOST"] = ollama_host
 groq_api_key = config.get("groq_api_key", "")
 os.environ["GROQ_API_KEY"] = groq_api_key
 
+astraflow_api_key = config.get("astraflow_api_key", "")
+astraflow_api_key = os.environ.get("ASTRAFLOW_API_KEY", astraflow_api_key)
+os.environ["ASTRAFLOW_API_KEY"] = astraflow_api_key
+
+astraflow_cn_api_key = config.get("astraflow_cn_api_key", "")
+astraflow_cn_api_key = os.environ.get("ASTRAFLOW_CN_API_KEY", astraflow_cn_api_key)
+os.environ["ASTRAFLOW_CN_API_KEY"] = astraflow_cn_api_key
+
 load_config_to_environ(["openai_api_type", "azure_openai_api_key", "azure_openai_api_base_url",
                        "azure_openai_api_version", "azure_deployment_name", "azure_embedding_deployment_name", "azure_embedding_model_name"])
 

--- a/modules/models/base_model.py
+++ b/modules/models/base_model.py
@@ -161,6 +161,7 @@ class ModelType(Enum):
     Ollama = 21
     Groq = 22
     DeepSeek = 23
+    Astraflow = 24
 
     @classmethod
     def get_type(cls, model_name: str):
@@ -227,6 +228,8 @@ class ModelType(Enum):
             model_type = ModelType.GoogleGemma
         elif "deepseek" in model_name_lower:
             model_type = ModelType.DeepSeek
+        elif "astraflow" in model_name_lower:
+            model_type = ModelType.Astraflow
         else:
             model_type = ModelType.LLaMA
         return model_type

--- a/modules/models/models.py
+++ b/modules/models/models.py
@@ -47,6 +47,15 @@ def get_model(
             logging.info(access_key)
             model = OpenAIVisionClient(
                 model_name, api_key=access_key, user_name=user_name)
+        elif model_type == ModelType.Astraflow:
+            logging.info(f"正在加载 Astraflow 模型: {model_name}")
+            from .OpenAIVision import OpenAIVisionClient
+            if "CN" in model_name:
+                access_key = os.environ.get("ASTRAFLOW_CN_API_KEY", access_key)
+            else:
+                access_key = os.environ.get("ASTRAFLOW_API_KEY", access_key)
+            model = OpenAIVisionClient(
+                model_name, api_key=access_key, user_name=user_name)
         elif model_type == ModelType.OpenAIInstruct:
             logging.info(f"正在加载OpenAI Instruct模型: {model_name}")
             from .OpenAIInstruct import OpenAI_Instruct_Client

--- a/modules/presets.py
+++ b/modules/presets.py
@@ -79,6 +79,8 @@ ONLINE_MODELS = [
     "Groq LLaMA2 70B",
     "Groq Mixtral 8x7B",
     "Groq Gemma 7B",
+    "Astraflow",
+    "Astraflow CN",
     "GooglePaLM",
     "Gemma 2B",
     "Gemma 7B",
@@ -558,6 +560,22 @@ MODEL_METADATA = {
         "token_limit": 64000,
         "multimodal": False,
         "model_type": "DeepSeek"
+    },
+    "Astraflow": {
+        "model_name": "astraflow",
+        "api_host": "https://api-us-ca.umodelverse.ai/v1",
+        "description": "Astraflow by UCloud — OpenAI-compatible platform supporting 200+ models (global endpoint)",
+        "token_limit": 128000,
+        "multimodal": False,
+        "model_type": "Astraflow"
+    },
+    "Astraflow CN": {
+        "model_name": "astraflow-cn",
+        "api_host": "https://api.modelverse.cn/v1",
+        "description": "Astraflow by UCloud — OpenAI-compatible platform supporting 200+ models (China endpoint)",
+        "token_limit": 128000,
+        "multimodal": False,
+        "model_type": "Astraflow"
     }
 }
 


### PR DESCRIPTION
## 作者自述
### 描述
为 ChuanhuChatGPT 添加 **Astraflow**（由 UCloud / 优刻得提供）作为新的支持供应商。

Astraflow 是一个兼容 OpenAI API 的 AI 模型聚合平台，支持 200+ 个模型。由于其 API 完全兼容 OpenAI，本次集成复用了现有的 `OpenAIVisionClient`，与 DeepSeek 供应商的集成模式完全一致，无需引入新依赖。

**主要变更：**

- **`modules/models/base_model.py`**：在 `ModelType` 枚举中添加 `Astraflow = 24`；在 `ModelType.get_type()` 中添加 `elif "astraflow" in model_name_lower` 分支以自动识别模型类型。
- **`modules/presets.py`**：在 `ONLINE_MODELS` 列表中添加 `"Astraflow"` 和 `"Astraflow CN"`；在 `MODEL_METADATA` 中添加两个端点的元数据（全球端点 `https://api-us-ca.umodelverse.ai/v1`，中国端点 `https://api.modelverse.cn/v1`）。
- **`modules/models/models.py`**：在 `get_model()` 中添加 `elif model_type == ModelType.Astraflow` 分支，分别读取 `ASTRAFLOW_API_KEY`（全球）或 `ASTRAFLOW_CN_API_KEY`（中国）环境变量并委托给 `OpenAIVisionClient`。
- **`modules/config.py`**：从 `config.json` 中加载 `astraflow_api_key` 和 `astraflow_cn_api_key`，并将其作为环境变量 `ASTRAFLOW_API_KEY` / `ASTRAFLOW_CN_API_KEY` 暴露，与其他供应商保持一致。
- **`config_example.json`**：新增 `"astraflow_api_key"` 和 `"astraflow_cn_api_key"` 字段及说明注释，便于用户获取密钥。

**供应商端点信息：**

| 字段 | 全球 | 中国 |
|---|---|---|
| Base URL | `https://api-us-ca.umodelverse.ai/v1` | `https://api.modelverse.cn/v1` |
| 环境变量 | `ASTRAFLOW_API_KEY` | `ASTRAFLOW_CN_API_KEY` |
| Config 键名 | `astraflow_api_key` | `astraflow_cn_api_key` |
| 注册地址 | https://astraflow.ucloud-global.com | https://astraflow.ucloud.cn |

截图（运行效果）：N/A

### 相关问题
无

### 补充信息
本次集成完全复用现有 `OpenAIVisionClient`，不引入任何新依赖，也不修改现有供应商的逻辑，变更范围最小化。


<!-- ############ Copilot for pull request ############
     不要删除下面的内容！ DO NOT DELETE THE CONTENT BELOW! 

## Copilot4PR [decrepated on 2023-12-15]
copilot:all
-->